### PR TITLE
docs: add link to OpenSCAD standalone version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ A web application that generates 3D-printable STL files for braille embossing pl
 - **Configurable Parameters** — Adjust dot dimensions, spacing, and surface settings
 - **Zero-Maintenance Deployment** — No external services, no expiring caches, no secrets to manage
 
+## 🖥️ OpenSCAD Version (Offline Alternative)
+
+Want to work offline or integrate with existing CAD workflows? Check out the **standalone OpenSCAD version**:
+
+| | Web App (this repo) | OpenSCAD Version |
+|---|---------------------|------------------|
+| **Repository** | You're here! | [braille-stl-generator-openscad](https://github.com/BrennenJohnston/braille-stl-generator-openscad) |
+| **Translation** | Automatic (liblouis) | Manual ([Branah.com](https://www.branah.com/braille-translator)) |
+| **Runtime** | Browser | Local OpenSCAD app |
+| **Best For** | Quick generation, no install | Offline use, parametric control, batch processing |
+
 ## Zero-Maintenance Architecture
 
 v2.0.0 is designed for **"deploy once, run forever"** operation:


### PR DESCRIPTION
Adds a section to the README linking to the new standalone OpenSCAD repository:

**https://github.com/BrennenJohnston/braille-stl-generator-openscad**

This provides users with an offline alternative that offers:
- Full parametric control
- Integration with existing OpenSCAD/CAD workflows  
- Batch processing capability
- No browser required

The comparison table helps users choose the right version for their needs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an "OpenSCAD Version (Offline Alternative)" section to `README.md` linking to the standalone repository and outlining when to use it.
> 
> - Introduces link to `braille-stl-generator-openscad` for offline/parametric workflows
> - Adds a concise comparison table (repository, translation method, runtime, best-for) between the web app and OpenSCAD version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adf0c86d70aee56029aaf8b26615ea027e5770f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->