### PR TITLE
feat(openscad): include OpenSCAD project files and docs in main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,6 @@ tmp_spec_direct.py
 # Vercel Runtime Logs (diagnostic exports - do not commit)
 Vercel Runtime Logs/
 
-# OpenSCAD version (work in progress - to be revisited)
-OpenSCAD/
-
 # BANA Fact Sheet source artifacts (regenerated on demand by scripts/fetch_bana_business_cards.py)
 docs/guides/_bana_source/
 

--- a/OpenSCAD/Braille_Card_And_Cylinder_STL_Generator.scad
+++ b/OpenSCAD/Braille_Card_And_Cylinder_STL_Generator.scad
@@ -1,0 +1,761 @@
+// Braille Cylinder STL Generator (OpenSCAD)
+// Generates embossing plates and counter plates for cylindrical objects
+//
+// =============================================================================
+// WHAT THIS MAKES
+// =============================================================================
+//  • Cylinder Emboss Plate (Raised Dots) — dots on outer cylinder surface
+//  • Cylinder Counter Plate (Hemispherical Recesses) — recesses on outer surface
+//
+// =============================================================================
+// BEFORE YOU START
+// =============================================================================
+//  • Install OpenSCAD and open this .scad file
+//  • In OpenSCAD, open View → Customizer to access all parameters
+//  • This version requires pre-translated Unicode braille (no automatic translation)
+//  • All parameters match the web-based generator UI for consistency
+//
+// =============================================================================
+// TRANSLATE YOUR TEXT (REQUIRED) — BRANAH WORKFLOW
+// =============================================================================
+//  This OpenSCAD version does NOT include automatic translation. You must:
+//  
+//  1. Go to https://www.branah.com/braille-translator
+//  2. In the options, select your desired braille grade:
+//     - Grade 2 (contracted): Recommended for most uses
+//     - Grade 1 (uncontracted): For names, emails, or when contractions cause confusion
+//  3. Select Unicode Braille output (NOT ASCII Braille)
+//  4. Type your English text in the left box
+//  5. Copy the braille output (right box showing characters like ⠓⠑⠇⠇⠕)
+//  6. In OpenSCAD's Customizer, paste into the Line_1, Line_2, etc. fields
+//
+//  IMPORTANT: If you paste ordinary English letters or see "INVALID CHARACTERS"
+//  warning, re-translate on Branah and ensure Unicode Braille is selected.
+//
+// =============================================================================
+// QUICK START GUIDE
+// =============================================================================
+//  1. Translate your text at https://www.branah.com/braille-translator
+//  2. Paste pre-translated braille into Line_1, Line_2, etc.
+//  3. Choose plate_type: Embossing Plate or Counter Plate
+//  4. Choose dot_shape: Rounded or Cone (affects both plates)
+//  5. Adjust dimensions in Expert Mode if needed
+//  6. Render (F6) → File → Export → STL
+//
+// =============================================================================
+// PARAMETER ORGANIZATION
+// =============================================================================
+//  Parameters are organized to match the web-based generator:
+//
+//  MAIN CONTROLS (always visible):
+//  • Text Input - Pre-Translated Braille
+//  • Plate Selection
+//
+//  EXPERT MODE (expandable submenus matching web UI):
+//  • Expert Mode - Shape Selection (dot shapes, indicators)
+//  • Expert Mode - Cylinder Dimensions
+//  • Expert Mode - Braille Spacing (grid layout + positioning)
+//  • Expert Mode - Braille Dot Adjustments (emboss/counter dimensions)
+//
+//  OPENSCAD-SPECIFIC:
+//  • Rendering Quality
+//
+// =============================================================================
+// REFERENCES
+// =============================================================================
+//  [1] Web-based Generator (with automatic translation): 
+//      https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator
+//      https://braille-card-and-cylinder-stl-gener.vercel.app
+//  [2] Branah Braille Translator: https://www.branah.com/braille-translator
+//  [3] BANA — Size and Spacing: https://brailleauthority.org/size-and-spacing-braille-characters
+//  [4] NLS — Specification 800: https://www.loc.gov/nls/
+//  [5] 2010 ADA Standards: https://archive.ada.gov/
+//
+// =============================================================================
+// ACKNOWLEDGMENTS
+// =============================================================================
+//  This OpenSCAD version is based on the web-based generator by Brennen Johnston.
+//  Special thanks to Tobi Weinberg for the substantial time and effort volunteered
+//  to help start the original project.
+//
+//  Original web app powered by Liblouis, an open-source professional braille
+//  translator: https://liblouis.io/
+// =============================================================================
+
+/* [Text Input - Pre-Translated Braille] */
+// Paste Unicode braille characters from https://www.branah.com/braille-translator
+Line_1 = "⠓⠑⠇⠇⠕"; // First line of braille text
+Line_2 = "⠺⠕⠗⠇⠙"; // Second line of braille text
+Line_3 = ""; // Third line of braille text
+Line_4 = ""; // Fourth line of braille text
+
+/* [Plate Selection] */
+// Choose which plate to generate
+plate_type = "Embossing Plate"; // [Embossing Plate, Counter Plate]
+
+/* [Paper Thickness Preset] */
+// Preset optimized for paper thickness (sets multiple parameters below)
+paper_thickness_preset = "0.4mm"; // [0.4mm, 0.3mm, Custom]
+
+/* [Expert Mode - Shape Selection] */
+// Braille Dot Shape (Emboss and Counter) - affects both plate types
+dot_shape = "Rounded"; // [Rounded, Cone]
+// Indicator Shapes (Emboss and Counter) - Row start/end markers
+indicators = "On"; // [On, Off]
+
+/* [Expert Mode - Cylinder Dimensions] */
+cylinder_diameter_mm = 30.8; // [10:0.1:100] Cylinder outer diameter in mm
+cylinder_height_mm = 52; // [20:1:150] Cylinder height in mm
+polygon_cutout_radius_mm = 13.0; // [0:0.1:50] Polygonal cutout circumscribed radius (0 = no cutout)
+polygon_cutout_points = 12; // [3:1:24] Number of sides/points for polygonal cutout
+seam_offset_degrees = 0.0; // [0:1:360] Seam offset (degrees) — Rotates starting position around cylinder
+
+/* [Expert Mode - Braille Spacing] */
+// --- Braille Dimensions ---
+grid_columns = 11; // [1:1:20] Number of braille cells per row available for text (2 cells reserved for indicators when On)
+grid_rows = 4; // [1:1:10] Number of lines of braille
+cell_spacing = 6.5; // [2:0.1:15] Horizontal spacing between cells (mm)
+line_spacing = 10.0; // [5:0.1:25] Vertical spacing between lines (mm)
+dot_spacing = 2.5; // [1:0.1:5] Spacing between dots within a cell (mm)
+
+// --- Braille Positioning ---
+braille_x_adjust = 0.0; // [-10:0.1:10] Horizontal adjustment of braille pattern (mm)
+braille_y_adjust = 0.0; // [-10:0.1:10] Vertical adjustment of braille pattern (mm)
+
+/* [Expert Mode - Braille Dot Adjustments] */
+// --- Embossing Braille Dot Dimensions (Rounded Shape) ---
+rounded_dot_base_diameter = 1.5; // [0.5:0.1:3] Rounded dot base diameter (cone base) (mm)
+rounded_dot_base_height = 0.5; // [0:0.1:2] Rounded dot base height (cone height) (mm)
+rounded_dot_dome_diameter = 1.0; // [0.5:0.1:3] Rounded dome diameter (linked to cone flat top) (mm)
+rounded_dot_dome_height = 0.5; // [0.1:0.1:2] Rounded dot dome height (mm)
+
+// --- Embossing Braille Dot Dimensions (Cone Shape) ---
+emboss_dot_base_diameter = 1.5; // [0.5:0.1:3] Cone dot base diameter (mm)
+emboss_dot_height = 0.8; // [0.3:0.1:2] Cone dot height (mm)
+emboss_dot_flat_hat = 0.4; // [0.1:0.1:2] Cone dot flat hat diameter (mm)
+
+// --- Counter Braille Recessed Dot Dimensions (Rounded Shape / Bowl) ---
+bowl_counter_dot_base_diameter = 1.8; // [0.5:0.1:5] Bowl recess base diameter (mm)
+counter_dot_depth = 0.8; // [0.1:0.1:2] Bowl recess depth (mm)
+
+// --- Counter Braille Recessed Dot Dimensions (Cone Shape) ---
+cone_counter_dot_base_diameter = 1.9; // [0.5:0.1:3] Cone recess base diameter (mm)
+cone_counter_dot_height = 0.7; // [0.3:0.1:2] Cone recess height (mm)
+cone_counter_dot_flat_hat = 1.0; // [0.1:0.1:2] Cone recess flat hat diameter (mm)
+
+/* [Rendering Quality] */
+// Sphere quality for rounded shapes
+render_quality = "Medium"; // [Low, Medium, High]
+// Cone segments for cone shapes (8-32 range recommended)
+cone_segments = 16; // [8:1:64] Number of segments for cone shapes
+
+/* [Hidden] */
+$fn = 32; // Resolution for curved surfaces
+
+// Mathematical constants
+PI = 3.14159265359;
+
+// =============================================================================
+// PRESET VALUE CONSTANTS
+// =============================================================================
+// Source: Web app THICKNESS_PRESETS in public/index.html
+// These values are applied when paper_thickness_preset is "0.4mm" or "0.3mm"
+
+// --------- 0.4mm Preset (Thicker Paper, Larger Dots) ---------
+// Spacing
+_p04_grid_columns = 11;
+_p04_grid_rows = 4;
+_p04_cell_spacing = 6.5;
+_p04_line_spacing = 10.0;
+_p04_dot_spacing = 2.5;
+_p04_braille_x_adjust = 0.0;
+_p04_braille_y_adjust = 0.0;
+
+// Emboss Rounded
+_p04_rounded_dot_base_diameter = 1.5;
+_p04_rounded_dot_base_height = 0.5;
+_p04_rounded_dot_dome_diameter = 1.0;
+_p04_rounded_dot_dome_height = 0.5;
+
+// Emboss Cone
+_p04_emboss_dot_base_diameter = 1.5;
+_p04_emboss_dot_height = 0.8;
+_p04_emboss_dot_flat_hat = 0.4;
+
+// Counter Bowl
+_p04_bowl_counter_dot_base_diameter = 1.8;
+_p04_counter_dot_depth = 0.8;
+
+// Counter Cone
+_p04_cone_counter_dot_base_diameter = 1.9;
+_p04_cone_counter_dot_height = 0.7;
+_p04_cone_counter_dot_flat_hat = 1.0;
+
+// Cylinder
+_p04_cylinder_diameter_mm = 30.8;
+_p04_cylinder_height_mm = 52;
+_p04_polygon_cutout_radius_mm = 13;
+_p04_polygon_cutout_points = 12;
+_p04_seam_offset_degrees = 0.0;
+
+// --------- 0.3mm Preset (Thinner Paper, Smaller Dots) ---------
+// Spacing (same as 0.4mm)
+_p03_grid_columns = 11;
+_p03_grid_rows = 4;
+_p03_cell_spacing = 6.5;
+_p03_line_spacing = 10.0;
+_p03_dot_spacing = 2.5;
+_p03_braille_x_adjust = 0.0;
+_p03_braille_y_adjust = 0.0;
+
+// Emboss Rounded (smaller)
+_p03_rounded_dot_base_diameter = 1.2;
+_p03_rounded_dot_base_height = 0.4;
+_p03_rounded_dot_dome_diameter = 0.8;
+_p03_rounded_dot_dome_height = 0.4;
+
+// Emboss Cone (smaller)
+_p03_emboss_dot_base_diameter = 1.2;
+_p03_emboss_dot_height = 0.6;
+_p03_emboss_dot_flat_hat = 0.2;
+
+// Counter Bowl (smaller)
+_p03_bowl_counter_dot_base_diameter = 1.5;
+_p03_counter_dot_depth = 0.5;
+
+// Counter Cone (smaller)
+_p03_cone_counter_dot_base_diameter = 1.5;
+_p03_cone_counter_dot_height = 0.5;
+_p03_cone_counter_dot_flat_hat = 0.8;
+
+// Cylinder (same as 0.4mm)
+_p03_cylinder_diameter_mm = 30.8;
+_p03_cylinder_height_mm = 52;
+_p03_polygon_cutout_radius_mm = 13;
+_p03_polygon_cutout_points = 12;
+_p03_seam_offset_degrees = 0.0;
+
+// =============================================================================
+// BACKWARD COMPATIBILITY - Test System Parameters
+// =============================================================================
+// The automated test system passes parameters via -D flags using these names.
+// These hidden parameters allow the test system to work without modification.
+//
+// Usage: openscad -D 'combined_shape="rounded"' -D 'indicator_shapes="on"' ...
+//
+combined_shape = "";         // "rounded" or "cone" (from test system)
+indicator_shapes = "";       // "on" or "off" (from test system)
+hemisphere_quality = "";     // "low", "medium", "high" (from test system)
+shape_type = "";             // "cylinder" (from test system, ignored - cylinder only)
+
+// =============================================================================
+// CALCULATED VALUES (Do not modify)
+// =============================================================================
+
+// Normalize dropdown selections to internal values
+// Support both UI dropdowns (human-friendly) and test system parameters (lowercase)
+is_emboss_plate = (plate_type == "positive") ? true :
+                  (plate_type == "negative") ? false :
+                  (plate_type == "Embossing Plate");
+
+use_rounded_dots = (combined_shape == "rounded") ? true :
+                   (combined_shape == "cone") ? false :
+                   (dot_shape == "Rounded");
+
+indicator_on = (indicator_shapes == "on") ? true :
+               (indicator_shapes == "off") ? false :
+               (indicators == "On");
+
+// Map render quality to segment counts (support both UI and test system)
+quality_fn = (hemisphere_quality == "low" || render_quality == "Low") ? 24 :
+             (hemisphere_quality == "medium" || render_quality == "Medium") ? 32 :
+             (hemisphere_quality == "high" || render_quality == "High") ? 64 : 32;
+
+// =============================================================================
+// PRESET ROUTING - Select preset vs. custom values
+// =============================================================================
+// These variables route between preset constants and user parameters based on
+// paper_thickness_preset selection. Pattern: preset value if "0.4mm" or "0.3mm",
+// otherwise use the user's manual parameter setting.
+
+// Spacing parameters
+_preset_grid_columns = (paper_thickness_preset == "0.4mm") ? _p04_grid_columns :
+                       (paper_thickness_preset == "0.3mm") ? _p03_grid_columns :
+                       grid_columns;
+
+_preset_grid_rows = (paper_thickness_preset == "0.4mm") ? _p04_grid_rows :
+                    (paper_thickness_preset == "0.3mm") ? _p03_grid_rows :
+                    grid_rows;
+
+_preset_cell_spacing = (paper_thickness_preset == "0.4mm") ? _p04_cell_spacing :
+                       (paper_thickness_preset == "0.3mm") ? _p03_cell_spacing :
+                       cell_spacing;
+
+_preset_line_spacing = (paper_thickness_preset == "0.4mm") ? _p04_line_spacing :
+                       (paper_thickness_preset == "0.3mm") ? _p03_line_spacing :
+                       line_spacing;
+
+_preset_dot_spacing = (paper_thickness_preset == "0.4mm") ? _p04_dot_spacing :
+                      (paper_thickness_preset == "0.3mm") ? _p03_dot_spacing :
+                      dot_spacing;
+
+_preset_braille_x_adjust = (paper_thickness_preset == "0.4mm") ? _p04_braille_x_adjust :
+                           (paper_thickness_preset == "0.3mm") ? _p03_braille_x_adjust :
+                           braille_x_adjust;
+
+_preset_braille_y_adjust = (paper_thickness_preset == "0.4mm") ? _p04_braille_y_adjust :
+                           (paper_thickness_preset == "0.3mm") ? _p03_braille_y_adjust :
+                           braille_y_adjust;
+
+// Emboss Rounded parameters
+_preset_rounded_dot_base_diameter = (paper_thickness_preset == "0.4mm") ? _p04_rounded_dot_base_diameter :
+                                    (paper_thickness_preset == "0.3mm") ? _p03_rounded_dot_base_diameter :
+                                    rounded_dot_base_diameter;
+
+_preset_rounded_dot_base_height = (paper_thickness_preset == "0.4mm") ? _p04_rounded_dot_base_height :
+                                  (paper_thickness_preset == "0.3mm") ? _p03_rounded_dot_base_height :
+                                  rounded_dot_base_height;
+
+_preset_rounded_dot_dome_diameter = (paper_thickness_preset == "0.4mm") ? _p04_rounded_dot_dome_diameter :
+                                    (paper_thickness_preset == "0.3mm") ? _p03_rounded_dot_dome_diameter :
+                                    rounded_dot_dome_diameter;
+
+_preset_rounded_dot_dome_height = (paper_thickness_preset == "0.4mm") ? _p04_rounded_dot_dome_height :
+                                  (paper_thickness_preset == "0.3mm") ? _p03_rounded_dot_dome_height :
+                                  rounded_dot_dome_height;
+
+// Emboss Cone parameters
+_preset_emboss_dot_base_diameter = (paper_thickness_preset == "0.4mm") ? _p04_emboss_dot_base_diameter :
+                                   (paper_thickness_preset == "0.3mm") ? _p03_emboss_dot_base_diameter :
+                                   emboss_dot_base_diameter;
+
+_preset_emboss_dot_height = (paper_thickness_preset == "0.4mm") ? _p04_emboss_dot_height :
+                            (paper_thickness_preset == "0.3mm") ? _p03_emboss_dot_height :
+                            emboss_dot_height;
+
+_preset_emboss_dot_flat_hat = (paper_thickness_preset == "0.4mm") ? _p04_emboss_dot_flat_hat :
+                              (paper_thickness_preset == "0.3mm") ? _p03_emboss_dot_flat_hat :
+                              emboss_dot_flat_hat;
+
+// Counter Bowl parameters
+_preset_bowl_counter_dot_base_diameter = (paper_thickness_preset == "0.4mm") ? _p04_bowl_counter_dot_base_diameter :
+                                         (paper_thickness_preset == "0.3mm") ? _p03_bowl_counter_dot_base_diameter :
+                                         bowl_counter_dot_base_diameter;
+
+_preset_counter_dot_depth = (paper_thickness_preset == "0.4mm") ? _p04_counter_dot_depth :
+                            (paper_thickness_preset == "0.3mm") ? _p03_counter_dot_depth :
+                            counter_dot_depth;
+
+// Counter Cone parameters
+_preset_cone_counter_dot_base_diameter = (paper_thickness_preset == "0.4mm") ? _p04_cone_counter_dot_base_diameter :
+                                         (paper_thickness_preset == "0.3mm") ? _p03_cone_counter_dot_base_diameter :
+                                         cone_counter_dot_base_diameter;
+
+_preset_cone_counter_dot_height = (paper_thickness_preset == "0.4mm") ? _p04_cone_counter_dot_height :
+                                  (paper_thickness_preset == "0.3mm") ? _p03_cone_counter_dot_height :
+                                  cone_counter_dot_height;
+
+_preset_cone_counter_dot_flat_hat = (paper_thickness_preset == "0.4mm") ? _p04_cone_counter_dot_flat_hat :
+                                    (paper_thickness_preset == "0.3mm") ? _p03_cone_counter_dot_flat_hat :
+                                    cone_counter_dot_flat_hat;
+
+// Cylinder parameters
+_preset_cylinder_diameter_mm = (paper_thickness_preset == "0.4mm") ? _p04_cylinder_diameter_mm :
+                               (paper_thickness_preset == "0.3mm") ? _p03_cylinder_diameter_mm :
+                               cylinder_diameter_mm;
+
+_preset_cylinder_height_mm = (paper_thickness_preset == "0.4mm") ? _p04_cylinder_height_mm :
+                             (paper_thickness_preset == "0.3mm") ? _p03_cylinder_height_mm :
+                             cylinder_height_mm;
+
+_preset_polygon_cutout_radius_mm = (paper_thickness_preset == "0.4mm") ? _p04_polygon_cutout_radius_mm :
+                                   (paper_thickness_preset == "0.3mm") ? _p03_polygon_cutout_radius_mm :
+                                   polygon_cutout_radius_mm;
+
+_preset_polygon_cutout_points = (paper_thickness_preset == "0.4mm") ? _p04_polygon_cutout_points :
+                                (paper_thickness_preset == "0.3mm") ? _p03_polygon_cutout_points :
+                                polygon_cutout_points;
+
+_preset_seam_offset_degrees = (paper_thickness_preset == "0.4mm") ? _p04_seam_offset_degrees :
+                              (paper_thickness_preset == "0.3mm") ? _p03_seam_offset_degrees :
+                              seam_offset_degrees;
+
+// =============================================================================
+// ACTIVE PARAMETERS - Final values used by geometry
+// =============================================================================
+// These variables provide the final parameter values used by the geometry code.
+// They incorporate both preset routing (above) and shape-based routing (rounded vs cone).
+
+// Active emboss dot parameters (based on shape selection, using preset-routed values)
+active_emboss_base_diameter = use_rounded_dots ? _preset_rounded_dot_base_diameter : _preset_emboss_dot_base_diameter;
+active_emboss_height = use_rounded_dots ? (_preset_rounded_dot_base_height + _preset_rounded_dot_dome_height) : _preset_emboss_dot_height;
+active_emboss_top_diameter = use_rounded_dots ? _preset_rounded_dot_dome_diameter : _preset_emboss_dot_flat_hat;
+
+// Active counter dot parameters (based on shape selection, using preset-routed values)
+active_counter_base_diameter = use_rounded_dots ? _preset_bowl_counter_dot_base_diameter : _preset_cone_counter_dot_base_diameter;
+active_counter_height = use_rounded_dots ? _preset_counter_dot_depth : _preset_cone_counter_dot_height;
+active_counter_top_diameter = use_rounded_dots ? 0 : _preset_cone_counter_dot_flat_hat;
+
+// Active spacing parameters (pass through from preset routing)
+active_grid_columns = _preset_grid_columns;
+active_grid_rows = _preset_grid_rows;
+active_cell_spacing = _preset_cell_spacing;
+active_line_spacing = _preset_line_spacing;
+active_dot_spacing = _preset_dot_spacing;
+active_braille_x_adjust = _preset_braille_x_adjust;
+active_braille_y_adjust = _preset_braille_y_adjust;
+
+// Active cylinder parameters (pass through from preset routing)
+active_cylinder_diameter_mm = _preset_cylinder_diameter_mm;
+active_cylinder_height_mm = _preset_cylinder_height_mm;
+active_polygon_cutout_radius_mm = _preset_polygon_cutout_radius_mm;
+active_polygon_cutout_points = _preset_polygon_cutout_points;
+active_seam_offset_degrees = _preset_seam_offset_degrees;
+
+// Grid dimensions (accounting for indicator shapes if enabled)
+actual_grid_columns = indicator_on ? (active_grid_columns + 2) : active_grid_columns;
+grid_width = (actual_grid_columns - 1) * active_cell_spacing;
+grid_height = (active_grid_rows - 1) * active_line_spacing;
+top_margin = (active_cylinder_height_mm - grid_height) / 2;
+
+// Counter plate recess radii (spherical cap formula to match web generator)
+// For a bowl recess: R = (a² + h²) / (2h) where a = opening radius, h = depth
+// This ensures the opening diameter = bowl_counter_dot_base_diameter and depth = counter_dot_depth
+_bowl_a = _preset_bowl_counter_dot_base_diameter / 2;
+_bowl_h = _preset_counter_dot_depth;
+bowl_recess_radius = (_bowl_a * _bowl_a + _bowl_h * _bowl_h) / (2 * _bowl_h);
+bowl_center_offset = bowl_recess_radius - _bowl_h;
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+// Check if a character is valid Unicode braille (U+2800 to U+28FF)
+function is_braille_char(c) = (c >= 10240 && c <= 10495);
+
+// Check if string contains invalid characters
+function has_invalid_chars(str) = 
+    len(str) == 0 ? false : 
+    len([for (i = [0:len(str)-1]) if (!is_braille_char(ord(str[i]))) i]) > 0;
+
+// Get the 6-dot pattern from a Unicode braille character
+function get_dot_pattern(char) =
+    let(code = ord(char))
+    (code >= 10240 && code <= 10495) ?
+        let(pattern = code - 10240)
+        [
+            (pattern % 2) >= 1 ? 1 : 0,              // Dot 1
+            floor(pattern / 2) % 2 >= 1 ? 1 : 0,     // Dot 2
+            floor(pattern / 4) % 2 >= 1 ? 1 : 0,     // Dot 3
+            floor(pattern / 8) % 2 >= 1 ? 1 : 0,     // Dot 4
+            floor(pattern / 16) % 2 >= 1 ? 1 : 0,    // Dot 5
+            floor(pattern / 32) % 2 >= 1 ? 1 : 0     // Dot 6
+        ]
+    : [0,0,0,0,0,0]; // Empty pattern for non-braille
+
+// =============================================================================
+// INDICATOR SHAPE MODULES
+// =============================================================================
+//
+// Reference: braille-card-and-cylinder-stl-generator/docs/specifications/
+//   RECESS_INDICATOR_SPECIFICATIONS.md
+//
+// CRITICAL SEMANTICS:
+// - Indicators are ALWAYS RECESSED (subtracted) for BOTH emboss and counter plates.
+// - Cylinder layout (when indicators ON):
+//     Column 0: Triangle marker (counter plate triangle rotated 180°)
+//     Column 1: Rectangle placeholder (counter ALWAYS rectangle; emboss uses rect for braille input)
+//
+INDICATOR_TRIANGLE_DEPTH_EMBOSS = 0.6;
+INDICATOR_RECT_DEPTH_EMBOSS = 0.5;
+
+module indicator_triangle_2d(rotate_180 = false) {
+    // Isosceles triangle with vertical base on LEFT, apex RIGHT (default).
+    // When rotate_180=true, triangle is rotated 180° about its center.
+    polygon(points = rotate_180 ?
+        [
+            [+active_dot_spacing/2, +active_dot_spacing],
+            [+active_dot_spacing/2, -active_dot_spacing],
+            [-active_dot_spacing/2, 0]
+        ] :
+        [
+            [-active_dot_spacing/2, -active_dot_spacing],
+            [-active_dot_spacing/2, +active_dot_spacing],
+            [+active_dot_spacing/2, 0]
+        ]
+    );
+}
+
+module indicator_rectangle_2d() {
+    // Rectangle is NOT centered on the cell center; it is centered at (x + dot_spacing/2, y).
+    translate([active_dot_spacing/2, 0])
+        square([active_dot_spacing, 2 * active_dot_spacing], center = true);
+}
+
+module indicator_triangle_prism_centered(depth, rotate_180 = false) {
+    translate([0, 0, -depth/2])
+        linear_extrude(height = depth)
+            indicator_triangle_2d(rotate_180 = rotate_180);
+}
+
+module indicator_rectangle_prism_centered(depth) {
+    translate([0, 0, -depth/2])
+        linear_extrude(height = depth)
+            indicator_rectangle_2d();
+}
+
+// Cylinder marker placement helper
+module place_cylinder_marker(theta_deg, y_pos, cyl_radius, depth, overcut = 0.05) {
+    radial_offset = cyl_radius - depth/2 + overcut;
+    x = radial_offset * cos(theta_deg);
+    y = radial_offset * sin(theta_deg);
+    translate([x, y, y_pos])
+        rotate([90, 0, theta_deg - 90])
+            children();
+}
+
+// =============================================================================
+// DOT CREATION MODULES
+// =============================================================================
+
+// Create an embossing braille dot CENTERED at origin for CYLINDER surface
+// Geometry spans from -totalHeight/2 to +totalHeight/2 along Z axis
+module braille_dot_centered() {
+    _total_height = use_rounded_dots ? 
+                    (_preset_rounded_dot_base_height + _preset_rounded_dot_dome_height) : 
+                    _preset_emboss_dot_height;
+    
+    if (use_rounded_dots) {
+        // Spherical cap formula: R = (r² + h²) / (2h)
+        _dome_r = _preset_rounded_dot_dome_diameter / 2;
+        _R_sphere = (_dome_r * _dome_r + _preset_rounded_dot_dome_height * _preset_rounded_dot_dome_height) / (2 * _preset_rounded_dot_dome_height);
+        _center_z = _preset_rounded_dot_base_height + _preset_rounded_dot_dome_height - _R_sphere;
+        
+        // Center the combined geometry at Z=0
+        translate([0, 0, -_total_height / 2]) {
+            union() {
+                // Frustum base
+                translate([0, 0, _preset_rounded_dot_base_height / 2])
+                cylinder(
+                    h = _preset_rounded_dot_base_height,
+                    r1 = _preset_rounded_dot_base_diameter / 2,
+                    r2 = _preset_rounded_dot_dome_diameter / 2,
+                    center = true,
+                    $fn = cone_segments
+                );
+                // Dome: proper spherical cap
+                intersection() {
+                    translate([0, 0, _center_z])
+                    sphere(r = _R_sphere, $fn = quality_fn);
+                    translate([0, 0, _preset_rounded_dot_base_height + _R_sphere])
+                    cube([_R_sphere * 4, _R_sphere * 4, _R_sphere * 2], center = true);
+                }
+            }
+        }
+    } else {
+        // Cone frustum - already centered
+        cylinder(
+            h = _preset_emboss_dot_height,
+            r1 = _preset_emboss_dot_base_diameter / 2,
+            r2 = _preset_emboss_dot_flat_hat / 2,
+            center = true,
+            $fn = cone_segments
+        );
+    }
+}
+
+// Create a recess for counter plate (bowl or cone shape)
+module counter_recess() {
+    if (use_rounded_dots) {
+        // Bowl recess (spherical cap)
+        translate([0, 0, bowl_center_offset])
+        sphere(r = bowl_recess_radius, $fn = quality_fn);
+    } else {
+        // Cone frustum recess
+        translate([0, 0, -_preset_cone_counter_dot_height / 2])
+        cylinder(
+            h = _preset_cone_counter_dot_height,
+            r1 = _preset_cone_counter_dot_flat_hat / 2,
+            r2 = _preset_cone_counter_dot_base_diameter / 2,
+            center = true,
+            $fn = cone_segments
+        );
+    }
+}
+
+// =============================================================================
+// CYLINDER MODULES
+// =============================================================================
+
+module cylinder_shell(cutout_rotate_deg = 0) {
+    difference() {
+        // Outer cylinder (64 segments to match web generator)
+        cylinder(h = active_cylinder_height_mm, r = active_cylinder_diameter_mm / 2, center = true, $fn = 64);
+        
+        // Polygonal cutout if specified
+        if (active_polygon_cutout_radius_mm > 0) {
+            // Web UI: "Circumscribed Radius" but implementation uses inscribed radius
+            cutout_circumradius = active_polygon_cutout_radius_mm / cos(180 / active_polygon_cutout_points);
+            rotate([0, 0, cutout_rotate_deg])
+                cylinder(h = active_cylinder_height_mm + 2, r = cutout_circumradius, $fn = active_polygon_cutout_points, center = true);
+        }
+    }
+}
+
+module cylinder_emboss_plate() {
+    translate([0, 0, active_cylinder_height_mm/2]) {
+        // Calculate angular spacing
+        radius = active_cylinder_diameter_mm / 2;
+        grid_angle = grid_width / radius;
+        start_angle = -grid_angle / 2;
+        cell_spacing_angle = active_cell_spacing / radius;
+
+        // Dot positioning
+        dot_spacing_angle = active_dot_spacing / radius;
+        dot_col_angle_offsets = [-dot_spacing_angle / 2, dot_spacing_angle / 2];
+        dot_row_offsets = [active_dot_spacing, 0, -active_dot_spacing];
+        dot_positions = [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]];
+
+        difference() {
+            union() {
+                // Base cylinder
+                cylinder_shell(cutout_rotate_deg = -active_seam_offset_degrees);
+
+                // Check for invalid characters
+                invalid_found = has_invalid_chars(Line_1) || has_invalid_chars(Line_2) ||
+                               has_invalid_chars(Line_3) || has_invalid_chars(Line_4);
+                
+                if (invalid_found) {
+                    translate([0, 0, active_cylinder_height_mm/2 + 5])
+                    color("red")
+                    linear_extrude(height = 2)
+                    text("INVALID CHARACTERS", size = 5, halign = "center", valign = "center");
+                }
+        
+                // Create braille dots on cylinder surface
+                lines = [Line_1, Line_2, Line_3, Line_4];
+                
+                for (row = [0 : min(active_grid_rows - 1, len(lines) - 1)]) {
+                    if (len(lines[row]) > 0) {
+                        y_pos = active_cylinder_height_mm/2 - top_margin - (row * active_line_spacing) + active_braille_y_adjust;
+                        
+                        for (col = [0 : min(active_grid_columns - 1, len(lines[row]) - 1)]) {
+                            actual_col = indicator_on ? (col + 2) : col;
+                            angle_rad = start_angle + (actual_col * cell_spacing_angle);
+                            angle_deg = angle_rad * 180 / PI;
+                            dots = get_dot_pattern(lines[row][col]);
+                            
+                            for (i = [0:5]) {
+                                if (dots[i] == 1) {
+                                    dot_pos = dot_positions[i];
+                                    dot_angle_rad = angle_rad + dot_col_angle_offsets[dot_pos[1]];
+                                    dot_angle_deg = dot_angle_rad * 180 / PI;
+                                    dot_y = y_pos + dot_row_offsets[dot_pos[0]];
+                                    
+                                    x = (radius + active_emboss_height/2) * cos(dot_angle_deg);
+                                    y = (radius + active_emboss_height/2) * sin(dot_angle_deg);
+                                    
+                                    translate([x, y, dot_y])
+                                        rotate([0, 90, dot_angle_deg])
+                                            braille_dot_centered();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Subtract indicator recesses if enabled
+            if (indicator_on) {
+                for (row = [0 : active_grid_rows - 1]) {
+                    y_pos = active_cylinder_height_mm/2 - top_margin - (row * active_line_spacing) + active_braille_y_adjust;
+
+                    // Column 0: Triangle marker (apex RIGHT)
+                    tri_theta_deg = start_angle * 180 / PI;
+                    place_cylinder_marker(tri_theta_deg, y_pos, radius, INDICATOR_TRIANGLE_DEPTH_EMBOSS)
+                        indicator_triangle_prism_centered(INDICATOR_TRIANGLE_DEPTH_EMBOSS, rotate_180 = false);
+
+                    // Column 1: Rectangle marker
+                    rect_theta_deg = (start_angle + cell_spacing_angle) * 180 / PI;
+                    place_cylinder_marker(rect_theta_deg, y_pos, radius, INDICATOR_RECT_DEPTH_EMBOSS)
+                        indicator_rectangle_prism_centered(INDICATOR_RECT_DEPTH_EMBOSS);
+                }
+            }
+        }
+    }
+}
+
+module cylinder_counter_plate() {
+    translate([0, 0, active_cylinder_height_mm/2])
+    difference() {
+        // Base cylinder
+        cylinder_shell(cutout_rotate_deg = active_seam_offset_degrees);
+        
+        // Calculate angular spacing
+        radius = active_cylinder_diameter_mm / 2;
+        grid_angle = grid_width / radius;
+        start_angle = -grid_angle / 2;
+        cell_spacing_angle = active_cell_spacing / radius;
+        
+        // Dot positioning
+        dot_spacing_angle = active_dot_spacing / radius;
+        dot_col_angle_offsets = [-dot_spacing_angle / 2, dot_spacing_angle / 2];
+        dot_row_offsets = [active_dot_spacing, 0, -active_dot_spacing];
+        dot_positions = [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]];
+        
+        // Create indicator recesses if enabled
+        if (indicator_on) {
+            for (row = [0 : active_grid_rows - 1]) {
+                y_pos = active_cylinder_height_mm/2 - top_margin - (row * active_line_spacing) + active_braille_y_adjust;
+
+                // Column 0: Triangle marker (ROTATED 180° on counter plate)
+                tri_theta_deg = -(start_angle * 180 / PI);
+                place_cylinder_marker(tri_theta_deg, y_pos, radius, active_counter_height)
+                    indicator_triangle_prism_centered(active_counter_height, rotate_180 = true);
+
+                // Column 1: Rectangle placeholder (ALWAYS rectangle on counter plates)
+                rect_theta_deg = -((start_angle + cell_spacing_angle) * 180 / PI);
+                place_cylinder_marker(rect_theta_deg, y_pos, radius, active_counter_height)
+                    indicator_rectangle_prism_centered(active_counter_height);
+            }
+        }
+        
+        // Create recesses for ALL possible dot positions
+        for (row = [0 : active_grid_rows - 1]) {
+            y_pos = active_cylinder_height_mm/2 - top_margin - (row * active_line_spacing) + active_braille_y_adjust;
+            
+            for (col = [0 : active_grid_columns - 1]) {
+                actual_col = indicator_on ? (col + 2) : col;
+                angle_rad = start_angle + (actual_col * cell_spacing_angle);
+                angle_deg = -(angle_rad * 180 / PI);
+                
+                for (i = [0:5]) {
+                    dot_pos = dot_positions[i];
+                    dot_angle_rad = angle_rad + dot_col_angle_offsets[dot_pos[1]];
+                    dot_angle_deg = -(dot_angle_rad * 180 / PI);
+                    dot_y = y_pos + dot_row_offsets[dot_pos[0]];
+                    
+                    recess_radius_offset = use_rounded_dots ? 0 : 0.05;
+                    x = (radius + recess_radius_offset) * cos(dot_angle_deg);
+                    y = (radius + recess_radius_offset) * sin(dot_angle_deg);
+                    
+                    translate([x, y, dot_y])
+                    rotate([0, 90, dot_angle_deg])
+                    counter_recess();
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// MAIN RENDERING
+// =============================================================================
+
+if (is_emboss_plate) {
+    cylinder_emboss_plate();
+} else {
+    cylinder_counter_plate();
+}
+
+// End of file

--- a/OpenSCAD/LICENSE
+++ b/OpenSCAD/LICENSE
@@ -1,0 +1,135 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Brennen Johnston (https://github.com/BrennenJohnston)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+---
+
+Required Notice: Copyright 2024-2025 Brennen Johnston (https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator)

--- a/OpenSCAD/PARAMETER_MAPPING.md
+++ b/OpenSCAD/PARAMETER_MAPPING.md
@@ -1,0 +1,210 @@
+# OpenSCAD to Web App Parameter Mapping
+
+This document maps the OpenSCAD customizer parameters to the web-based braille generator UI controls.
+
+**Note:** This repository contains only the OpenSCAD cylinder generator. For the web app source code, see [braille-card-and-cylinder-stl-generator](https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator). This mapping ensures the OpenSCAD Customizer stays aligned with web UI terminology and defaults.
+
+## Overview
+
+The OpenSCAD version has been updated to match the web-based generator's UI parameters. The only differences are:
+1. OpenSCAD requires **pre-translated Unicode braille** characters (no automatic translation)
+2. OpenSCAD is **cylinder-only** (card support removed)
+
+## Translation Workflow
+
+1. **Web App**: Automatic translation using Liblouis (Grade 1 or Grade 2)
+2. **OpenSCAD**: Manual translation required at https://www.branah.com/braille-translator
+   - User must select Grade 1 or Grade 2 manually
+   - Copy Unicode braille output
+   - Paste into OpenSCAD Line_1, Line_2, etc.
+
+## Parameter Mapping
+
+### Text Input - Pre-Translated Braille
+| OpenSCAD Parameter | Web App Equivalent | Notes |
+|--------------------|-------------------|-------|
+| `Line_1` | Line 1 text input | Must be pre-translated Unicode braille |
+| `Line_2` | Line 2 text input | Must be pre-translated Unicode braille |
+| `Line_3` | Line 3 text input | Must be pre-translated Unicode braille |
+| `Line_4` | Line 4 text input | Must be pre-translated Unicode braille |
+
+### Plate Selection
+| OpenSCAD Parameter | Web App Equivalent | Values |
+|--------------------|-------------------|--------|
+| `plate_type` | Select Plate to Generate | `"Embossing Plate"`, `"Counter Plate"` |
+
+### Paper Thickness Preset
+| OpenSCAD Parameter | Web App Equivalent | Default | Values |
+|--------------------|-------------------|---------|--------|
+| `paper_thickness_preset` | Card Thickness | `"0.4mm"` | `"0.4mm"`, `"0.3mm"`, `"Custom"` |
+
+**Note:** The web UI label is "Card Thickness" but this is NOT the removed card-geometry feature. This is a parametric memory system that automatically sets 24 parameters (spacing, dot dimensions, and cylinder settings) to known-good values optimized for different paper thicknesses. Selecting "0.4mm" or "0.3mm" forces all preset-controlled parameters to specific values. "Custom" indicates that values deviate from presets.
+
+### Expert Mode - Shape Selection
+| OpenSCAD Parameter | Web App Equivalent | Values |
+|--------------------|-------------------|--------|
+| `dot_shape` | Braille Dot Shape | `"Rounded"`, `"Cone"` |
+| `indicators` | Indicator Shapes | `"On"`, `"Off"` |
+
+### Expert Mode - Cylinder Dimensions
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `cylinder_diameter_mm` | Diameter | 30.8 mm | 10-100 mm |
+| `cylinder_height_mm` | Height | 52 mm | 20-150 mm |
+| `polygon_cutout_radius_mm` | Cutout Radius | 13.0 mm | 0-50 mm |
+| `polygon_cutout_points` | Cutout Points/Sides | 12 | 3-24 |
+| `seam_offset_degrees` | Seam Offset | 0.0° | 0-360° |
+
+### Expert Mode - Braille Spacing
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `grid_columns` | Number of Braille Cells | 11 | 1-20 |
+| `grid_rows` | Number of Braille Lines | 4 | 1-10 |
+| `cell_spacing` | Braille Cell Spacing | 6.5 mm | 2-15 mm |
+| `line_spacing` | Braille Line Spacing | 10.0 mm | 5-25 mm |
+| `dot_spacing` | Braille Dot Spacing | 2.5 mm | 1-5 mm |
+
+### Expert Mode - Braille Positioning
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `braille_x_adjust` | X Adjust | 0.0 mm | -10 to 10 mm |
+| `braille_y_adjust` | Y Adjust | 0.0 mm | -10 to 10 mm |
+
+### Expert Mode - Emboss Dot Dimensions (Rounded Shape)
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `rounded_dot_base_diameter` | Rounded dot base diameter (cone base) | 1.5 mm | 0.5-3 mm |
+| `rounded_dot_base_height` | Rounded dot base height (cone height) | 0.5 mm | 0-2 mm |
+| `rounded_dot_dome_diameter` | Rounded dome diameter | 1.0 mm | 0.5-3 mm |
+| `rounded_dot_dome_height` | Rounded dot dome height | 0.5 mm | 0.1-2 mm |
+
+### Expert Mode - Emboss Dot Dimensions (Cone Shape)
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `emboss_dot_base_diameter` | Dot diameter | 1.5 mm | 0.5-3 mm |
+| `emboss_dot_height` | Dot height | 0.8 mm | 0.3-2 mm |
+| `emboss_dot_flat_hat` | Flat hat diameter | 0.4 mm | 0.1-2 mm |
+
+### Expert Mode - Counter Dot Dimensions (Rounded Shape / Bowl)
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `bowl_counter_dot_base_diameter` | Bowl Recess Dot Base Diameter | 1.8 mm | 0.5-5 mm |
+| `counter_dot_depth` | Bowl Recess Depth | 0.8 mm | 0.1-2 mm |
+
+### Expert Mode - Counter Dot Dimensions (Cone Shape)
+| OpenSCAD Parameter | Web App Equivalent | Default | Range |
+|--------------------|-------------------|---------|-------|
+| `cone_counter_dot_base_diameter` | Cone recess base diameter | 1.9 mm | 0.5-3 mm |
+| `cone_counter_dot_height` | Cone recess height | 0.7 mm | 0.3-2 mm |
+| `cone_counter_dot_flat_hat` | Cone recess flat hat diameter | 1.0 mm | 0.1-2 mm |
+
+### Rendering Quality
+| OpenSCAD Parameter | Web App Equivalent | Default | Values |
+|--------------------|-------------------|---------|--------|
+| `render_quality` | Render Quality | `"Medium"` | `"Low"` (24 segments), `"Medium"` (32 segments), `"High"` (64 segments) |
+| `cone_segments` | Cone Segments | 16 | 8-64 |
+
+## Key Features Implemented
+
+### 1. **Unified Shape Selection**
+- `combined_shape` parameter controls both emboss and counter plate dot shapes
+- When set to `"rounded"`: Uses rounded dome dots for emboss, bowl recesses for counter
+- When set to `"cone"`: Uses cone frustum dots for emboss, cone recesses for counter
+
+### 2. **Indicator Shapes**
+- `indicator_shapes = "on"` (On): Adds start/end markers to each row
+  - Reserves 2 cells per row (1 at start, 1 at end for cards; 2 at start for cylinders)
+  - Cards: Rectangle at column 0, Triangle at column N-1
+  - Cylinders: Triangle at column 0, Rectangle at column 1
+  - Counter plates: Triangle rotated 180° (cylinders only), Rectangle always used (never character)
+  - Helps align plates during embossing
+- `indicator_shapes = "off"` (Off): All cells available for braille text
+
+### 3. **Flexible Counter Plate Recesses**
+- **Bowl Recess (Rounded)**: Spherical cap with adjustable diameter and depth
+- **Cone Recess (Cone)**: Frustum cone matching emboss dot shape
+- Universal counter plates work for all possible dot positions
+
+### 4. **Multiple Dot Shapes**
+- **Rounded**: Cone base + hemispherical dome (more comfortable to touch)
+- **Cone**: Frustum cone (traditional, easier to print)
+
+### 5. **Cylinder Support**
+- Full parametric control over diameter, height, and polygonal cutout
+- Seam offset allows rotation adjustment
+- Supports both rounded and cone dot shapes on curved surfaces
+
+## Default Values Alignment
+
+All default values match the web-based generator's defaults (0.4mm paper preset applied on load):
+- Cylinder: 30.8mm diameter × 52mm height
+- Grid: 11 text cells × 4 rows (with indicator shapes ON, 2 additional cells are reserved = 13 total)
+- Spacing matches BANA specifications
+- Default shape: Rounded (bowl recess for counter)
+- Default preset: 0.4mm (optimized for thicker paper, larger dots)
+
+## Workflow Comparison
+
+### Web App Workflow:
+1. Enter English text
+2. Select language/grade
+3. Choose shape and plate type
+4. Adjust expert parameters (optional)
+5. Generate STL
+6. Download
+
+### OpenSCAD Workflow:
+1. Translate text at https://www.branah.com/braille-translator
+2. Copy Unicode braille output
+3. Open OpenSCAD file
+4. Paste braille into Line_1, Line_2, etc.
+5. Choose shape_type and plate_type in Customizer
+6. Adjust expert parameters (optional)
+7. Render (F6)
+8. Export STL (File → Export → Export as STL)
+
+## Advantages of Each Version
+
+### Web App Advantages:
+- ✅ Automatic braille translation (Liblouis)
+- ✅ Live 3D preview in browser
+- ✅ No software installation required
+- ✅ Auto-placement mode (word wrapping)
+- ✅ Multi-language support (100+ braille tables)
+
+### OpenSCAD Advantages:
+- ✅ Works offline (after text translation)
+- ✅ Full parametric control in native CAD environment
+- ✅ Can modify and extend code
+- ✅ Integration with existing OpenSCAD workflows
+- ✅ Version control friendly (plain text .scad files)
+- ✅ Batch processing possible via command line
+
+## Notes
+
+1. **Paper Thickness Preset System**: This is a convenience system that sets 24 parameters to known-good values:
+   - **0.4mm preset** (thicker paper, larger dots): Default setting that matches web app on-load behavior
+   - **0.3mm preset** (thinner paper, smaller dots): Alternative optimized for thinner materials
+   - **Custom**: Indicator state when values deviate from presets
+   - The preset controls: spacing (7 params), emboss rounded (4 params), emboss cone (3 params), counter bowl (2 params), counter cone (3 params), and cylinder dimensions (5 params)
+   - Text, plate type, shape selection, and rendering quality remain user-controlled
+
+2. **Indicator Shapes**: When enabled (`indicator_shapes = "on"`), they reserve the first and last cell of each row. The `grid_columns` parameter represents the number of cells *available for text*, not including indicators. The code internally adds 2 cells when indicators are on.
+
+3. **Rounded vs. Cone**: The web app calls these "Rounded" and "Cone" - both terms refer to the combined emboss+counter shape pair.
+
+4. **Counter Plate Universality**: Counter plates have recesses at ALL possible dot positions (all 6 dots × all cells × all rows), making them universal for any braille pattern.
+
+5. **Parameter Names**: OpenSCAD uses snake_case (e.g., `grid_columns`) to match the web app's JavaScript variable names, ensuring consistency across platforms.
+
+6. **"Card Thickness" UI Label**: Despite the web UI label "Card Thickness", this preset system is NOT the removed card-geometry feature. It's a parametric memory system for setting multiple dials at once.
+
+## References
+
+- Web-based Generator: https://braille-card-and-cylinder-stl-gener.vercel.app
+- Web App Source: https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator
+- OpenSCAD Version: https://github.com/BrennenJohnston/braille-stl-generator-openscad
+- Branah Braille Translator: https://www.branah.com/braille-translator
+- BANA Size & Spacing: https://brailleauthority.org/size-and-spacing-braille-characters
+
+

--- a/OpenSCAD/README.md
+++ b/OpenSCAD/README.md
@@ -1,0 +1,230 @@
+﻿# Braille Cylinder STL Generator (OpenSCAD)
+
+> **About this folder.** This is the OpenSCAD version of the Braille STL Generator,
+> vendored into the main `braille-card-and-cylinder-stl-generator` repository so
+> users can download and use it without the browser app. The original standalone
+> repo at [BrennenJohnston/braille-stl-generator-openscad](https://github.com/BrennenJohnston/braille-stl-generator-openscad)
+> is no longer the active home for this project — please open issues and pull
+> requests against the main repository.
+>
+> **What you need:** just the file `Braille_Card_And_Cylinder_STL_Generator.scad`
+> and [OpenSCAD](https://openscad.org/) (2024.x or newer). Everything else in this
+> folder is documentation. See the *Quick Start* section below.
+
+Parametric OpenSCAD program for generating braille embossing plates and counter plates for cylindrical objects.
+
+[![STL Validation](https://github.com/BrennenJohnston/braille-stl-generator-openscad/actions/workflows/stl-validation.yml/badge.svg)](https://github.com/BrennenJohnston/braille-stl-generator-openscad/actions/workflows/stl-validation.yml)
+
+## 🔗 Related Project
+
+This is the **offline OpenSCAD companion** to the web-based Braille STL Generator:
+
+| Version | Link | Use Case |
+|---------|------|----------|
+| **Web App** | [braille-card-and-cylinder-stl-gener.vercel.app](https://braille-card-and-cylinder-stl-gener.vercel.app) | Browser-based with automatic translation |
+| **OpenSCAD** (this repo) | [github.com/BrennenJohnston/braille-stl-generator-openscad](https://github.com/BrennenJohnston/braille-stl-generator-openscad) | Offline use, full parametric control |
+| **Web App Source** | [github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator](https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator) | Web app source code |
+
+## ⚠️ Key Difference
+
+**This OpenSCAD version requires pre-translated Unicode braille text.** It does NOT include automatic translation.
+
+---
+
+## 🚀 Quick Start
+
+1. **Translate your text**:
+   - Go to https://www.branah.com/braille-translator
+   - Select Grade 1 or Grade 2 braille
+   - Ensure "Unicode Braille" is selected (NOT ASCII)
+   - Type your text and copy the braille output (e.g., ⠓⠑⠇⠇⠕)
+
+2. **Open in OpenSCAD**:
+   - Open `Braille_Card_And_Cylinder_STL_Generator.scad`
+   - Open the Customizer panel (View → Customizer)
+
+3. **Configure**:
+   - Paste braille into `Line_1`, `Line_2`, etc.
+   - Choose `plate_type`: Embossing Plate or Counter Plate
+   - Choose `paper_thickness_preset`: 0.4mm, 0.3mm, or Custom
+   - Choose `dot_shape`: Rounded or Cone
+
+4. **Generate**:
+   - Render: F6 (or Design → Render)
+   - Export: File → Export → Export as STL
+
+---
+
+## 📋 What This Makes
+
+- **Cylinder Emboss Plate**: Raised braille dots on cylindrical surface
+- **Cylinder Counter Plate**: Recessed support for embossing cylindrical objects
+
+## 🎯 Features
+
+### Shape Options
+- **Rounded**: Dome-shaped dots with spherical bowl recesses
+- **Cone**: Traditional frustum cone dots with matching cone recesses
+
+### Indicator Shapes
+- Optional start/end markers for each row (triangle and rectangle)
+- Helps with plate alignment during embossing
+- Reserves 2 cells per row when enabled
+
+### Paper Thickness Presets
+- **0.4mm Preset** (default): Optimized for thicker paper, larger dots
+- **0.3mm Preset**: Optimized for thinner paper, smaller dots
+- **Custom**: Use manually-entered parameter values
+
+The preset system controls 24 parameters at once (spacing, dot dimensions, cylinder settings) matching the web app's "Card Thickness" dropdown.
+
+### Parametric Control
+All parameters match the web-based generator UI:
+- Cylinder dimensions (diameter, height, cutout)
+- Braille spacing (cell, line, dot spacing)
+- Dot dimensions (separate controls for rounded and cone shapes)
+- Counter plate recess dimensions
+- Positioning adjustments (X/Y offsets)
+
+---
+
+## 📐 Default Settings
+
+All defaults match the web app's **0.4mm Paper Thickness Preset** (applied on load):
+
+### Cylinder Settings
+- Diameter: 30.8mm
+- Height: 52mm
+- Polygonal Cutout: 13mm radius, 12 points/sides
+- Seam Offset: 0°
+
+### Braille Grid
+- Cells per row: 11 (available for text; 2 additional cells reserved when indicators are on)
+- Number of rows: 4
+- Cell spacing: 6.5mm
+- Line spacing: 10.0mm
+- Dot spacing: 2.5mm
+
+### Dot Dimensions (Rounded - 0.4mm Preset)
+- Base diameter: 1.5mm
+- Base height: 0.5mm
+- Dome diameter: 1.0mm
+- Dome height: 0.5mm
+
+### Counter Plate (Bowl - 0.4mm Preset)
+- Base diameter: 1.8mm
+- Depth: 0.8mm
+
+---
+
+## 🖨️ 3D Printing Tips
+
+- **Material**: PLA works well; PETG is more durable
+- **Layer Height**: 0.1-0.2mm for smooth dots
+- **Infill**: 40%+ recommended for stiffness
+- **Perimeters**: 3-4 for strength
+- **Orientation**: Print upright as oriented in preview
+- **Speed**: Slower outer walls (≤30mm/s) for smoother dots
+
+---
+
+## 📚 Documentation
+
+| Document | Description |
+|----------|-------------|
+| [docs/WEB_TO_OPENSCAD_PORTING_GUIDE.md](docs/WEB_TO_OPENSCAD_PORTING_GUIDE.md) | Comprehensive guide for porting web generators to OpenSCAD |
+| [docs/OPENSCAD_COORDINATE_SYSTEM_SPECIFICATIONS.md](docs/OPENSCAD_COORDINATE_SYSTEM_SPECIFICATIONS.md) | Technical coordinate system documentation |
+| [docs/QUICK_START_TESTING.md](docs/QUICK_START_TESTING.md) | Notes from the original cross-platform validation suite (test files themselves are not vendored) |
+| [PARAMETER_MAPPING.md](PARAMETER_MAPPING.md) | Parameter mapping between OpenSCAD and web UI |
+
+---
+
+## 🧪 Automated Testing
+
+A cross-platform validation framework comparing OpenSCAD output against web-generated reference STLs was developed alongside this project. The test suite (≈30 fixtures, including binary STL references) is not vendored into this repository to keep the download lightweight. If you want to run those tests, see the historical snapshot at [github.com/BrennenJohnston/braille-stl-generator-openscad](https://github.com/BrennenJohnston/braille-stl-generator-openscad). For day-to-day OpenSCAD use, none of it is needed — just open the `.scad` file and use the Customizer.
+
+---
+
+## 🆚 Web App vs. OpenSCAD
+
+### Use Web App When:
+- ✅ You need automatic braille translation
+- ✅ You want live 3D preview
+- ✅ You prefer no software installation
+- ✅ You need multi-language support (100+ tables)
+
+### Use OpenSCAD When:
+- ✅ You want to work offline
+- ✅ You need full parametric control
+- ✅ You want to modify/extend the code
+- ✅ You have existing OpenSCAD workflows
+- ✅ You need version control (plain text files)
+- ✅ You want batch processing capability
+
+---
+
+## 🐛 Troubleshooting
+
+### "INVALID CHARACTERS" Warning
+- You pasted regular text instead of Unicode braille
+- Solution: Translate at Branah.com and copy the braille output
+
+### "TEXT TOO LONG" Warning
+- Your braille text exceeds `grid_columns` limit
+- Solution: Reduce text length or increase `grid_columns`
+
+### Dots Don't Align
+- Check `braille_x_adjust` and `braille_y_adjust`
+- Ensure spacing settings match between emboss and counter plates
+
+### Plates Don't Fit Together
+- Verify both plates use same `dot_shape` setting
+- Check that counter plate dimensions match emboss dimensions
+- Ensure `indicators` setting is same for both plates
+
+---
+
+## 📚 References
+
+1. **Web Generator**: https://braille-card-and-cylinder-stl-gener.vercel.app
+2. **Branah Translator**: https://www.branah.com/braille-translator
+3. **BANA Standards**: https://brailleauthority.org/size-and-spacing-braille-characters
+4. **NLS Spec 800**: https://www.loc.gov/nls/
+5. **ADA Standards**: https://archive.ada.gov/
+
+---
+
+## 🙏 Acknowledgments
+
+- **Brennen Johnston**: Original web-based generator
+- **Tobi Weinberg**: Project inception and development support
+- **Liblouis**: Professional braille translation library (used in web app)
+
+---
+
+## 📄 License
+
+This project is licensed under the **PolyForm Noncommercial License 1.0.0**.
+
+- ✅ Free for personal, educational, and non-commercial use
+- ✅ Modification and remixing allowed
+- ❌ **No commercial use permitted**
+
+See the [LICENSE](LICENSE) file for full terms.
+
+---
+
+## 📞 Support
+
+For issues specific to this OpenSCAD version:
+1. [Open an issue](https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator/issues) on the main repository (use the `OpenSCAD` label)
+2. Check parameter values in Customizer
+3. Verify Unicode braille character validity
+4. Ensure OpenSCAD version 2024.x or newer (2026.01.03+ recommended)
+
+For general braille embossing questions, see the [web app](https://braille-card-and-cylinder-stl-gener.vercel.app).
+
+---
+
+**Version**: 2.1.0  
+**Last Updated**: 2026-01-11

--- a/OpenSCAD/docs/OPENSCAD_COORDINATE_SYSTEM_SPECIFICATIONS.md
+++ b/OpenSCAD/docs/OPENSCAD_COORDINATE_SYSTEM_SPECIFICATIONS.md
@@ -1,0 +1,418 @@
+# OpenSCAD Braille Generator - Coordinate System and Geometry Specifications
+
+## Version History
+| Date | Version | Changes |
+|------|---------|---------|
+| 2024-12-09 | 1.0 | Initial specification document |
+
+---
+
+## 1. OpenSCAD Coordinate System
+
+### 1.1 Global Coordinate System
+
+OpenSCAD uses a **right-handed Z-up coordinate system**:
+
+```
+        Z (up)
+        |
+        |
+        |_______ Y
+       /
+      /
+     X
+```
+
+| Axis | Direction | Braille Context |
+|------|-----------|-----------------|
+| X | Right | Around cylinder circumference (angular) |
+| Y | Forward | Height along cylinder axis |
+| Z | Up | Radial outward from cylinder center |
+
+### 1.2 Cylinder Orientation
+
+The cylinder is generated with its axis along Z, then positioned upright for printing:
+
+```openscad
+// Cylinder with axis along Z (height = cylinder_height_mm)
+cylinder(h = cylinder_height_mm, r = cylinder_diameter_mm / 2, center = true);
+
+// After translate([0, 0, cylinder_height_mm/2]):
+// - Cylinder base at Z=0
+// - Cylinder top at Z=cylinder_height_mm
+// - Cylinder axis along Z
+```
+
+**IMPORTANT:** In the context of dot placement on cylinder surfaces:
+- The cylinder's Z-axis corresponds to the "height" direction
+- Dots are placed radially outward in the XY-plane
+- Angular position θ determines X,Y coordinates: `(r*cos(θ), r*sin(θ))`
+
+---
+
+## 2. Braille Dot Geometry Construction
+
+### 2.1 Rounded Dot Structure
+
+The rounded dot consists of two parts:
+
+```
+                    ┌───────┐
+                   /  DOME   \     ← Spherical cap (dome_height)
+                  /           \
+                 └─────────────┘   ← Dome base = Frustum top
+                /               \
+               /    FRUSTUM      \  ← Conical frustum (base_height)
+              /                   \
+             └─────────────────────┘ ← Frustum base (base_diameter)
+```
+
+### 2.2 Geometry Construction (Card Surface - Base at Z=0)
+
+For **cards**, the dot is built with its base at Z=0:
+
+```openscad
+// Frustum: spans z=0 to z=base_height
+translate([0, 0, base_height / 2])
+cylinder(h = base_height, r1 = base_radius, r2 = top_radius, center = true);
+
+// Dome: base at z=base_height, top at z=base_height+dome_height
+// (spherical cap positioned at top of frustum)
+```
+
+**Geometry bounds:** `z ∈ [0, base_height + dome_height]`
+
+### 2.3 Geometry Construction (Cylinder Surface - Centered at Origin)
+
+For **cylinders**, the dot must be centered at Z=0 for correct radial positioning:
+
+```openscad
+// Total height
+total_height = base_height + dome_height;
+
+// Create centered geometry
+translate([0, 0, -total_height / 2]) {
+    // Same frustum + dome construction as cards
+    // This translation centers the combined geometry at Z=0
+}
+```
+
+**Geometry bounds after centering:** `z ∈ [-total_height/2, +total_height/2]`
+
+---
+
+## 3. Cylinder Surface Positioning
+
+### 3.1 The Rotation-Translation Sequence
+
+To place a dot on the cylinder surface:
+
+```openscad
+translate([radialOffset * cos(θ), radialOffset * sin(θ), height_position])
+rotate([0, 90, θ])
+centered_dot();
+```
+
+The order of transformations in OpenSCAD is **right-to-left** (innermost first):
+1. `centered_dot()` - Create dot geometry centered at origin, axis along +Z
+2. `rotate([0, 90, θ])` - Rotate to point radially outward at angle θ
+3. `translate(...)` - Move to position on cylinder surface
+
+### 3.2 Understanding `rotate([0, 90, θ])`
+
+OpenSCAD applies rotations around the **original (global) axes** in order X, Y, Z:
+
+| Step | Rotation | Effect on +Z axis |
+|------|----------|-------------------|
+| 1 | 0° around X | No change |
+| 2 | 90° around Y | +Z → +X (dot now points along +X) |
+| 3 | θ° around Z | +X → (cos(θ), sin(θ), 0) (radial direction) |
+
+**Result:** The dot's original +Z axis now points in the radial direction at angle θ.
+
+### 3.3 Point Transformation Analysis
+
+For a centered dot with geometry spanning `z ∈ [-h/2, +h/2]`:
+
+| Original Point | After rotate([0, 90, θ]) | After translate to (R·cos(θ), R·sin(θ), z_pos) |
+|----------------|--------------------------|------------------------------------------------|
+| (0, 0, -h/2) | (-h/2·cos(θ), -h/2·sin(θ), 0) | ((R - h/2)·cos(θ), (R - h/2)·sin(θ), z_pos) |
+| (0, 0, 0) | (0, 0, 0) | (R·cos(θ), R·sin(θ), z_pos) |
+| (0, 0, +h/2) | (+h/2·cos(θ), +h/2·sin(θ), 0) | ((R + h/2)·cos(θ), (R + h/2)·sin(θ), z_pos) |
+
+Where `R = radialOffset` and `h = total_height`.
+
+### 3.4 Radial Offset Formula for Protrusions
+
+For a **centered** dot to sit flush with the cylinder surface:
+
+```
+radialOffset = cylRadius + total_height / 2
+```
+
+**Verification:**
+- Dot base (at z = -h/2 originally) → radial distance = R - h/2 = cylRadius ✓ (flush with surface)
+- Dot top (at z = +h/2 originally) → radial distance = R + h/2 = cylRadius + h ✓ (extends outward)
+
+### 3.5 CRITICAL: Why Centering is Required
+
+If the dot is **NOT** centered (base at z=0, top at z=h):
+
+| Original Point | After rotate | After translate to (R·cos(θ), R·sin(θ), z_pos) |
+|----------------|--------------|------------------------------------------------|
+| (0, 0, 0) [base] | (0, 0, 0) | (R·cos(θ), R·sin(θ), z_pos) |
+| (0, 0, h) [top] | (h·cos(θ), h·sin(θ), 0) | ((R + h)·cos(θ), (R + h)·sin(θ), z_pos) |
+
+With `R = cylRadius + h/2`:
+- Base at radial distance = R = cylRadius + h/2 ❌ (GAP of h/2 from surface!)
+- Top at radial distance = R + h = cylRadius + 3h/2 ❌
+
+**This is why the "stable" version had floating dots!**
+
+---
+
+## 4. Comparison with Other Coordinate Systems
+
+### 4.1 Python Backend (trimesh) - Z-up
+
+```python
+# Frustum created centered at origin: z ∈ [-base_h/2, +base_h/2]
+frustum = trimesh.creation.cylinder(radius=base_radius, height=base_h)
+
+# Dome positioned at top of frustum
+# Combined geometry: z ∈ [-base_h/2, base_h/2 + dome_h]
+
+# Center offset correction:
+# Geometric center is at z = dome_h / 2
+# Translation by [0, 0, -dome_h / 2] centers at origin
+dot.apply_translation([0.0, 0.0, -dome_h / 2.0])
+```
+
+### 4.2 Three.js CSG Worker - Y-up
+
+```javascript
+// Three.js uses Y-up, so "height" direction is Y
+// Frustum: y ∈ [-base_h/2, +base_h/2] (CylinderGeometry is centered)
+// Dome positioned at y = base_h/2
+// Combined: y ∈ [-base_h/2, base_h/2 + dome_h]
+
+// Center correction:
+geometry.translate(0, -validDomeHeight / 2, 0);
+
+// For cylinder surface:
+geometry.rotateZ(-Math.PI / 2);  // Y-axis → X-axis
+geometry.rotateY(-theta);         // Orient radially
+```
+
+### 4.3 OpenSCAD - Z-up (Different Construction)
+
+```openscad
+// OpenSCAD frustum with center=true is centered
+// But we translate it up to start at z=0:
+translate([0, 0, base_height / 2])
+cylinder(h = base_height, center = true);
+// Result: z ∈ [0, base_height]
+
+// Combined geometry: z ∈ [0, base_height + dome_height]
+// Geometric center at z = (base_height + dome_height) / 2
+
+// To center at z=0:
+translate([0, 0, -(base_height + dome_height) / 2])
+```
+
+**KEY DIFFERENCE:** OpenSCAD's construction starts at z=0, not centered like Python/Three.js. Therefore, the centering translation must be `-(total_height / 2)`, not `-(dome_height / 2)`.
+
+---
+
+## 5. Dome Orientation
+
+### 5.1 Correct Dome Orientation
+
+The dome (spherical cap) must point **outward** from the cylinder surface:
+
+```
+  Cylinder       Dot (correct)
+  Surface
+    |            ┌───┐
+    |           /DOME \   ← Dome faces outward
+    |__________|_______|
+              FRUSTUM
+```
+
+### 5.2 How Rotation Affects Dome Position
+
+After `rotate([0, 90, θ])`:
+- Original +Z (where dome points) → radial outward direction
+- Original -Z (frustum base) → radial inward direction
+
+For a centered dot:
+- Dome (at +z side) ends up at outer edge (correct ✓)
+- Frustum base (at -z side) ends up at cylinder surface (correct ✓)
+
+---
+
+## 6. Complete Cylinder Dot Placement Algorithm
+
+### 6.1 Pseudocode
+
+```
+For each braille dot on cylinder surface:
+    1. Calculate angular position θ (radians)
+    2. Calculate height position z_pos along cylinder axis
+    3. Calculate total dot height: h = base_height + dome_height
+    4. Calculate radial offset: R = cylRadius + h/2
+    5. Create centered dot geometry (z ∈ [-h/2, +h/2])
+    6. Rotate: rotate([0, 90, θ * 180/π])
+    7. Translate: translate([R*cos(θ), R*sin(θ), z_pos])
+```
+
+### 6.2 OpenSCAD Implementation
+
+```openscad
+module braille_dot_centered_cylinder() {
+    total_height = rounded_dot_base_height + rounded_dot_dome_height;
+    
+    // Center the geometry at origin
+    translate([0, 0, -total_height / 2]) {
+        union() {
+            // Frustum: z = 0 to z = base_height
+            translate([0, 0, rounded_dot_base_height / 2])
+            cylinder(
+                h = rounded_dot_base_height,
+                r1 = rounded_dot_base_diameter / 2,
+                r2 = rounded_dot_dome_diameter / 2,
+                center = true
+            );
+            // Dome: z = base_height to z = base_height + dome_height
+            // (spherical cap or scaled sphere)
+        }
+    }
+}
+
+// Placement on cylinder:
+theta_deg = angle_rad * 180 / PI + seam_offset_degrees;
+radial_offset = radius + active_emboss_height / 2;
+
+translate([radial_offset * cos(theta_deg), radial_offset * sin(theta_deg), z_position])
+rotate([0, 90, theta_deg])
+braille_dot_centered_cylinder();
+```
+
+---
+
+## 7. Validation Checklist
+
+### 7.1 Visual Verification
+
+- [ ] Dot base touches cylinder outer surface (no gap)
+- [ ] Dome points radially outward (not inward)
+- [ ] Dots maintain correct position at various cylinder diameters
+- [ ] Dot height extends outward from surface
+
+### 7.2 Numerical Verification
+
+For a dot with:
+- `base_height = 0.2mm`
+- `dome_height = 0.6mm`
+- `total_height = 0.8mm`
+- `cylinder_radius = 15mm`
+
+Expected:
+- `radialOffset = 15 + 0.4 = 15.4mm`
+- Dot base at radial distance: `15.4 - 0.4 = 15.0mm` (cylinder surface ✓)
+- Dot top at radial distance: `15.4 + 0.4 = 15.8mm` (0.8mm above surface ✓)
+
+---
+
+## 8. Cone Dot Handling
+
+### 8.1 Cone Dots Are Already Centered
+
+When using `center = true` with OpenSCAD's `cylinder()`:
+
+```openscad
+cylinder(h = height, r1 = base_r, r2 = top_r, center = true);
+// Geometry: z ∈ [-height/2, +height/2] ✓ Already centered
+```
+
+No additional centering translation is needed for cone dots.
+
+### 8.2 Comparison Table
+
+| Dot Type | Original Bounds | Centering Translation | Final Bounds |
+|----------|-----------------|----------------------|--------------|
+| Cone | [-h/2, +h/2] | None needed | [-h/2, +h/2] |
+| Rounded | [0, base_h + dome_h] | `-(base_h + dome_h) / 2` | [-total_h/2, +total_h/2] |
+
+---
+
+## 9. Related Documentation
+
+- `README.md` - Overview and usage
+- `Braille_Card_And_Cylinder_STL_Generator.scad` - Main OpenSCAD implementation
+- `PARAMETER_MAPPING.md` - OpenSCAD to web UI parameter correspondence
+
+Note: This document includes some historical comparison notes to the Python/Three.js implementation used by the web app. The web app source/specs are not present in this OpenSCAD-only branch.
+
+---
+
+## 10. Known Issues and Solutions
+
+### Issue 1: Floating Rounded Dots (FIXED)
+
+**Symptom:** Gap between dot base and cylinder surface.
+
+**Cause:** Using card-style dot (base at z=0) with cylinder positioning formula without centering.
+
+**Solution:** Use centered dot geometry for cylinder placement with `translate([0, 0, -total_height/2])`.
+
+### Issue 2: Inverted Dome Orientation (FIXED)
+
+**Symptom:** Dome points inward toward cylinder center.
+
+**Cause:** Incorrect centering translation using Python/JS formula instead of OpenSCAD-specific formula.
+
+**Solution:** The centering translation must be `-(base_height + dome_height) / 2`, not `-(dome_height / 2)`.
+
+### Issue 3: Truncated Dome / Wrong Sphere Center (FIXED)
+
+**Symptom:** Dome appears flat-topped instead of smoothly curved; small gap persists.
+
+**Cause:** When using spherical cap geometry, the sphere center formula was incorrect:
+- **Wrong:** `center_z = base_height + (R_sphere - dome_height)`
+- **Correct:** `center_z = base_height + dome_height - R_sphere`
+
+The wrong formula places the sphere center too high, causing the sphere apex to extend beyond the clipping region.
+
+**Solution:** Use correct spherical cap formula matching Python backend:
+```openscad
+// Calculate sphere radius for spherical cap
+_dome_r = dome_diameter / 2;
+_R_sphere = (_dome_r² + dome_height²) / (2 * dome_height);
+
+// Sphere center positioned so cap base = dome_diameter, apex at correct height
+_center_z = base_height + dome_height - _R_sphere;
+
+intersection() {
+    translate([0, 0, _center_z])
+    sphere(r = _R_sphere);
+    // Clip to only show cap above z = base_height
+    translate([0, 0, base_height + _R_sphere])
+    cube([_R_sphere * 4, _R_sphere * 4, _R_sphere * 2], center = true);
+}
+```
+
+**Verification (with defaults: dome_diameter=1.5mm, dome_height=0.6mm):**
+- R_sphere = (0.75² + 0.6²) / (2 × 0.6) = 0.76875mm
+- center_z = 0.2 + 0.6 - 0.76875 = 0.03125mm
+- At z = 0.2 (joint): sphere radius = sqrt(R² - (0.2 - 0.03125)²) = sqrt(0.591 - 0.0285) = 0.75mm ✓
+- This exactly matches dome_diameter/2 = 0.75mm → seamless joint!
+
+### Issue 4: Mismatched Frustum/Dome Junction (FIXED)
+
+**Symptom:** Dome diameter doesn't match frustum top diameter; visible seam or step at the joint.
+
+**Cause:** Using scaled sphere approach instead of proper spherical cap. A scaled sphere creates an ellipsoid where the equator radius doesn't match the intended dome base.
+
+**Solution:** Use proper spherical cap formula (see Issue 3). The formula `R = (r² + h²) / (2h)` ensures that the sphere cross-section at the cap base has exactly radius `r = dome_diameter/2`, creating a perfect match with the frustum top.
+

--- a/OpenSCAD/docs/QUICK_START_TESTING.md
+++ b/OpenSCAD/docs/QUICK_START_TESTING.md
@@ -1,0 +1,332 @@
+# Quick Start: Cross-Platform STL Validation
+
+Fast-track guide to using the comprehensive STL testing framework.
+
+## Prerequisites
+
+```bash
+# 1. Install OpenSCAD 2026.01.03+ with Manifold backend
+# Download from: https://openscad.org/downloads.html#snapshots
+
+# 2. Install Python dependencies
+pip install -r tests/requirements.txt
+
+# 3. (Optional) Install Playwright for web fixture generation
+pip install playwright
+python -m playwright install chromium
+
+# 4. (Optional) Install CloudCompare for surface deviation checks
+# See tests/tool_versions.yml for installation instructions
+```
+
+## Running Tests
+
+### Basic Test Run (Baseline Tolerances)
+
+```bash
+# Run all 11 cylinder tests
+pytest tests/cross_platform_validation.py -v
+
+# Run specific test
+pytest tests/cross_platform_validation.py::TestCrossPlatformValidation::test_stl_validation[cylinder_rounded_emboss_indicators_on] -v
+
+# Run only indicator isolation tests
+pytest tests/cross_platform_validation.py -k "indicator_recess" -v
+```
+
+### Strict Validation (Tight Tolerances)
+
+```bash
+# Run with strict comparison profile
+pytest tests/cross_platform_validation.py --comparison-config=tests/compare_config_strict.json -v
+
+# Or set environment variable
+export COMPARISON_CONFIG=tests/compare_config_strict.json
+pytest tests/cross_platform_validation.py -v
+```
+
+### Skip CloudCompare (if not installed)
+
+```bash
+pytest tests/cross_platform_validation.py --skip-cloudcompare -v
+```
+
+## Generating Fixtures
+
+### Current Status
+
+⚠️ **Current fixtures are OpenSCAD self-test mode** (not true cross-platform validation)
+
+You need to generate web reference fixtures first!
+
+### Generate Web Reference Fixtures (Playwright)
+
+```bash
+# 1. Update selectors in scripts/generate_web_fixtures.py to match your web UI
+# 2. Run generator against deployed web app
+
+# Generate all fixtures
+python scripts/generate_web_fixtures.py --web-url https://your-web-generator.com
+
+# Generate single fixture (debug mode with visible browser)
+python scripts/generate_web_fixtures.py \
+  --web-url https://your-web-generator.com \
+  --test-case cylinder_rounded_emboss_indicators_on \
+  --no-headless
+
+# Dry run (check setup)
+python scripts/generate_web_fixtures.py --web-url https://your-web-generator.com --dry-run
+```
+
+### Generate OpenSCAD Fixtures (Self-Test Mode)
+
+⚠️ **Not recommended for cross-platform validation** (only validates OpenSCAD internal consistency)
+
+```bash
+# Generate all fixtures
+python scripts/regenerate_fixtures.py --openscad-mode
+
+# Generate single fixture
+python scripts/regenerate_fixtures.py --openscad-mode --test-case cylinder_rounded_emboss_indicators_on
+```
+
+## Understanding Test Results
+
+### Test Output
+
+```
+tests/cross_platform_validation.py::TestCrossPlatformValidation::test_stl_validation[cylinder_rounded_emboss_indicators_on]
+  OpenSCAD: Generating STL...
+  ✓ Generated in 12.3s
+  Comparison:
+    Volume: 1234.56 mm³ (ref) vs 1235.12 mm³ (test) - diff: 0.05% ✓
+    Surface Area: 2345.67 mm² (ref) vs 2346.01 mm² (test) - diff: 0.01% ✓
+    Bounding Box: [0,0,0] to [30.75,52.0,30.75] - diff: 0.00mm ✓
+    Watertight: True (both) ✓
+    CloudCompare C2M: max 0.03mm ✓
+  PASSED
+```
+
+### Common Failures
+
+#### Volume/Area Mismatch
+
+```
+AssertionError: Volume difference 2.3% exceeds tolerance 1.0%
+```
+
+**Cause**: Geometry discrepancy between OpenSCAD and web generator  
+**Fix**: Investigate dot shape implementation (rounded vs cone)
+
+#### Indicator Recess Bug
+
+```
+AssertionError: Surface deviation 0.15mm exceeds tolerance 0.05mm
+Test: cylinder_indicator_recess_rounded
+```
+
+**Cause**: Known bug - indicator recesses not generating correctly in counter plates  
+**Fix**: Debug `cylinder_counter_plate()` module, check indicator placement/radius
+
+#### Watertightness Failure
+
+```
+AssertionError: Test mesh is not watertight (reference is watertight)
+```
+
+**Cause**: OpenSCAD boolean operation created non-manifold geometry  
+**Fix**: Check for overlapping/intersecting geometry, increase $fn if needed
+
+## Test Case Categories
+
+### Core Matrix (8 tests)
+
+All combinations: dot shape × plate type × indicators
+
+- `cylinder_rounded_emboss_indicators_on`
+- `cylinder_rounded_emboss_indicators_off`
+- `cylinder_rounded_counter_indicators_on`
+- `cylinder_rounded_counter_indicators_off`
+- `cylinder_cone_emboss_indicators_on`
+- `cylinder_cone_emboss_indicators_off`
+- `cylinder_cone_counter_indicators_on`
+- `cylinder_cone_counter_indicators_off`
+
+### Indicator Isolation (2 tests)
+
+Minimal fixtures for bug diagnosis (1 row, no text):
+
+- `cylinder_indicator_recess_rounded`
+- `cylinder_indicator_recess_cone`
+
+### Parametric Variation (1 test)
+
+Custom geometry:
+
+- `cylinder_rounded_emboss_custom_cutout`
+
+## Debugging Geometry Issues
+
+### Visual Inspection
+
+```bash
+# Generate test STL
+pytest tests/cross_platform_validation.py::TestCrossPlatformValidation::test_stl_validation[cylinder_rounded_emboss_indicators_on] -v
+
+# Find generated STL in test output directory
+# Open in MeshLab, Blender, or OpenSCAD for visual comparison
+```
+
+### Isolate Specific Geometry
+
+Use indicator isolation tests to focus on specific features:
+
+```bash
+# Test only indicator recesses (no braille dots)
+pytest tests/cross_platform_validation.py -k "indicator_recess" -v
+```
+
+### Compare Mesh Properties
+
+```bash
+# Run with verbose output
+pytest tests/cross_platform_validation.py -v -s
+
+# Check logs for detailed mesh properties:
+# - Volume, surface area, bounding box
+# - Face/vertex counts
+# - Watertightness status
+# - CloudCompare deviation statistics
+```
+
+## CI Integration
+
+### GitHub Actions Example
+
+```yaml
+name: STL Validation
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      CI: true  # Enables strict version enforcement
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true  # Pull STL fixtures from Git LFS
+      
+      - name: Install OpenSCAD 2026.01.03
+        run: |
+          wget -q https://files.openscad.org/snapshots/OpenSCAD-2026.01.03-x86_64.AppImage -O openscad.AppImage
+          chmod +x openscad.AppImage
+          sudo mv openscad.AppImage /usr/local/bin/openscad
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        run: pip install -r tests/requirements.txt
+      
+      - name: Run validation tests (baseline)
+        run: pytest tests/cross_platform_validation.py -v
+      
+      - name: Run validation tests (strict)
+        run: pytest tests/cross_platform_validation.py --comparison-config=tests/compare_config_strict.json -v
+```
+
+## Troubleshooting
+
+### OpenSCAD Not Found
+
+```
+OpenSCADNotFoundError: OpenSCAD executable not found
+```
+
+**Fix**: Install OpenSCAD 2026.01.03+ and add to PATH, or set `OPENSCAD_PATH` environment variable
+
+### Version Mismatch (CI Mode)
+
+```
+OpenSCADNotFoundError: OpenSCAD version mismatch!
+Required: 2026.01.03
+Found: OpenSCAD version 2021.01
+```
+
+**Fix**: Install exact version 2026.01.03 nightly (see tests/tool_versions.yml)
+
+### Manifold Backend Not Available
+
+```
+OpenSCADNotFoundError: Manifold backend is required but not available
+```
+
+**Fix**: Install OpenSCAD 2026.01.03+ nightly (stable releases don't have Manifold)
+
+### Card Test Case Blocked
+
+```
+pytest.fail: BLOCKED: Card test case 'card_rounded_emboss_basic' found in test_cases.json
+```
+
+**Fix**: This is intentional! Remove card test cases. Only cylinder tests are allowed until web UI parity is restored.
+
+### Fixtures Missing
+
+```
+FileNotFoundError: tests/fixtures/cross_platform/cylinder_rounded_emboss_indicators_on/reference.stl
+```
+
+**Fix**: Generate fixtures first (see "Generating Fixtures" section above)
+
+## Performance Tips
+
+### Speed Up Counter Plate Tests
+
+Counter plates use `hemisphere_quality="low"` and `cone_segments=8` for faster rendering (~5 min per test vs ~15 min with medium quality).
+
+### Parallel Execution
+
+```bash
+# Run tests in parallel (requires pytest-xdist)
+pip install pytest-xdist
+pytest tests/cross_platform_validation.py -n auto
+```
+
+⚠️ **Warning**: Parallel execution may cause issues with OpenSCAD file locking on some platforms.
+
+### Skip Slow Tests
+
+```bash
+# Skip counter plate tests (marked as slow_openscad)
+pytest tests/cross_platform_validation.py -m "not slow_openscad" -v
+```
+
+## Next Steps
+
+1. **Generate web reference fixtures** (update selectors in `scripts/generate_web_fixtures.py`)
+2. **Run baseline tests** to identify gross issues
+3. **Fix indicator recess bug** using isolation tests
+4. **Fix geometry discrepancies** identified by tests
+5. **Run strict tests** for final validation
+
+## Documentation
+
+- **Implementation Summary**: `IMPLEMENTATION_SUMMARY.md`
+- **Fixture Generation Guide**: `tests/fixtures/cross_platform/README_FIXTURE_GENERATION.md`
+- **Tool Versions**: `tests/tool_versions.yml`
+- **Comparison Config**: `tests/compare_config.json`, `tests/compare_config_strict.json`
+
+## Support
+
+For issues or questions:
+
+1. Check `IMPLEMENTATION_SUMMARY.md` for known issues
+2. Review fixture generation guide for setup problems
+3. Check tool_versions.yml for version requirements
+4. Examine test output logs for detailed error messages

--- a/OpenSCAD/docs/WEB_TO_OPENSCAD_PORTING_GUIDE.md
+++ b/OpenSCAD/docs/WEB_TO_OPENSCAD_PORTING_GUIDE.md
@@ -1,0 +1,1017 @@
+# Web-to-OpenSCAD Porting Guide
+
+A comprehensive guide for creating OpenSCAD implementations that match web-based 3D generators, with automated cross-platform validation.
+
+---
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Architecture Overview](#architecture-overview)
+3. [Phase 1: Analysis & Planning](#phase-1-analysis--planning)
+4. [Phase 2: Parameter Mapping](#phase-2-parameter-mapping)
+5. [Phase 3: Geometry Implementation](#phase-3-geometry-implementation)
+6. [Phase 4: Test Framework Setup](#phase-4-test-framework-setup)
+7. [Phase 5: Fixture Generation](#phase-5-fixture-generation)
+8. [Phase 6: Validation & Iteration](#phase-6-validation--iteration)
+9. [Phase 7: CI/CD Integration](#phase-7-cicd-integration)
+10. [Best Practices](#best-practices)
+11. [Troubleshooting](#troubleshooting)
+12. [Reference Implementation](#reference-implementation)
+
+---
+
+## Introduction
+
+### Purpose
+
+This guide documents the methodology for creating an OpenSCAD implementation of a web-based 3D generator that:
+
+1. **Matches geometry exactly** - Generated STL files are geometrically equivalent
+2. **Uses the same parameters** - UI controls map 1:1 between platforms
+3. **Has automated validation** - CI/CD catches regressions automatically
+4. **Maintains parity** - Changes to either platform are detected
+
+### Why OpenSCAD?
+
+OpenSCAD provides:
+- **Parametric design** - Easy customization via Customizer UI
+- **Reproducibility** - Same parameters always produce identical output
+- **Offline capability** - No server or internet required
+- **Open source** - No vendor lock-in
+- **3D printing friendly** - Direct STL export
+
+### Prerequisites
+
+- OpenSCAD 2024.x or later (2026.01.03+ recommended for Manifold backend)
+- Python 3.10+ with pip
+- Git with LFS support
+- Access to web generator source code or deployed instance
+- Basic understanding of 3D geometry and mesh concepts
+
+---
+
+## Architecture Overview
+
+### System Components
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Web-to-OpenSCAD Validation                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │
+│  │ Web Generator │    │   OpenSCAD   │    │  Validation  │       │
+│  │  (Reference)  │    │   Generator  │    │  Framework   │       │
+│  └──────┬───────┘    └──────┬───────┘    └──────┬───────┘       │
+│         │                   │                   │                │
+│         ▼                   ▼                   ▼                │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │
+│  │ Reference STL │    │  Test STL    │    │  Comparison  │       │
+│  │   Fixtures    │◄───│   Output     │───►│   Results    │       │
+│  └──────────────┘    └──────────────┘    └──────────────┘       │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Files
+
+```
+project/
+├── model.scad                      # OpenSCAD implementation
+├── tests/
+│   ├── parameter_mapping.json      # Parameter name/type mapping
+│   ├── compare_config.json         # Comparison tolerances
+│   ├── compare_config_strict.json  # Strict tolerances for CI
+│   ├── openscad_runner.py          # OpenSCAD CLI wrapper
+│   ├── mesh_comparison.py          # STL comparison logic
+│   ├── cross_platform_validation.py # Main test suite
+│   └── fixtures/
+│       └── cross_platform/
+│           ├── test_cases.json     # Test case definitions
+│           └── <test_name>/
+│               ├── reference.stl   # Web-generated reference
+│               ├── params.json     # Test parameters
+│               └── metadata.json   # Mesh properties
+├── scripts/
+│   ├── generate_web_fixtures.py    # Playwright fixture generator
+│   └── regenerate_fixtures.py      # Fixture management
+└── .github/
+    └── workflows/
+        └── stl-validation.yml      # CI/CD workflow
+```
+
+---
+
+## Phase 1: Analysis & Planning
+
+### Step 1.1: Understand the Web Generator
+
+Before writing any code, thoroughly analyze the web generator:
+
+1. **Identify all parameters**
+   - UI controls (dropdowns, sliders, text inputs)
+   - Hidden/computed parameters
+   - Default values
+
+2. **Document geometry primitives**
+   - What shapes are used? (cylinders, spheres, cones, etc.)
+   - How are they combined? (union, difference, intersection)
+   - What are the exact dimensions?
+
+3. **Map coordinate systems**
+   - Web generators often use Y-up (Three.js default)
+   - OpenSCAD uses Z-up
+   - Document transformation requirements
+
+4. **Identify tessellation settings**
+   - Sphere segment counts
+   - Cylinder face counts
+   - These affect mesh comparison
+
+### Step 1.2: Create Analysis Document
+
+Create a specification document covering:
+
+```markdown
+# Web Generator Analysis
+
+## Parameters
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|-------|-------------|
+| width     | float | 100 | 10-500 | Object width in mm |
+| ...       | ...   | ... | ...   | ... |
+
+## Geometry Primitives
+- Cylinder: radius=X, height=Y, segments=32
+- Sphere: radius=Z, segments=24
+- ...
+
+## Coordinate System
+- Web: Y-up, right-handed
+- OpenSCAD: Z-up, right-handed
+- Transform: rotate([90, 0, 0])
+
+## Boolean Operations
+1. Create base shape
+2. Subtract cutouts
+3. Add features
+```
+
+### Step 1.3: Define Test Matrix
+
+Plan your test cases to cover:
+
+- All parameter combinations (or representative subset)
+- Edge cases (min/max values)
+- Common use cases
+- Known problem areas
+
+Example matrix for a braille generator:
+
+| Test Case | Dot Shape | Plate Type | Indicators |
+|-----------|-----------|------------|------------|
+| test_1    | Rounded   | Emboss     | On         |
+| test_2    | Rounded   | Emboss     | Off        |
+| test_3    | Rounded   | Counter    | On         |
+| test_4    | Cone      | Emboss     | On         |
+| ...       | ...       | ...        | ...        |
+
+---
+
+## Phase 2: Parameter Mapping
+
+### Step 2.1: Create Parameter Mapping File
+
+Create `tests/parameter_mapping.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenSCAD to Web API Parameter Mapping",
+  "version": "1.0.0",
+  
+  "parameters": [
+    {
+      "openscad_name": "object_width",
+      "web_api_name": "width",
+      "web_ui_label": "Width (mm)",
+      "type": "float",
+      "default": 100.0,
+      "range": [10, 500],
+      "unit": "mm",
+      "section": "Dimensions",
+      "description": "Object width in millimeters"
+    },
+    {
+      "openscad_name": "shape_type",
+      "web_api_name": "shape",
+      "web_ui_label": "Shape",
+      "type": "enum",
+      "default": "Cylinder",
+      "values": ["Cylinder", "Box", "Sphere"],
+      "section": "Shape Selection",
+      "description": "Output shape type"
+    }
+  ],
+  
+  "validation_rules": {
+    "checks": [
+      {"name": "all_params_mapped", "severity": "error"},
+      {"name": "defaults_match", "severity": "error"},
+      {"name": "types_compatible", "severity": "error"}
+    ]
+  }
+}
+```
+
+### Step 2.2: OpenSCAD Customizer Best Practices
+
+**Dropdown Format (IMPORTANT)**
+
+Use human-readable labels directly, NOT `value:Label` format:
+
+```scad
+// ✅ CORRECT - Clean dropdown, no duplicates
+shape_type = "Cylinder"; // [Cylinder, Box, Sphere]
+
+// ❌ WRONG - Can cause duplicate entries
+shape_type = "cylinder"; // [cylinder:Cylinder, box:Box, sphere:Sphere]
+```
+
+**Backward Compatibility for Test System**
+
+If your test system uses different values (e.g., lowercase), add hidden parameters:
+
+```scad
+/* [Hidden] */
+// Test system compatibility - accepts lowercase values
+shape_type_test = "";  // "cylinder", "box", "sphere"
+
+// Normalize both UI and test values
+actual_shape = (shape_type_test == "cylinder") ? "Cylinder" :
+               (shape_type_test == "box") ? "Box" :
+               (shape_type_test == "sphere") ? "Sphere" :
+               shape_type;
+```
+
+### Step 2.3: Schema Validation Script
+
+Create `tests/validate_parameter_schema.py`:
+
+```python
+"""Validate OpenSCAD parameters match web API schema."""
+
+import json
+import re
+from pathlib import Path
+
+def extract_openscad_params(scad_file: Path) -> dict:
+    """Extract parameters from OpenSCAD Customizer sections."""
+    params = {}
+    content = scad_file.read_text()
+    
+    # Pattern: param_name = value; // [options] description
+    pattern = r'^(\w+)\s*=\s*([^;]+);(?:\s*//\s*(.*))?$'
+    
+    for line in content.split('\n'):
+        match = re.match(pattern, line.strip())
+        if match:
+            name, value, comment = match.groups()
+            params[name] = {
+                'default': parse_value(value),
+                'comment': comment or ''
+            }
+    
+    return params
+
+def validate_mapping(scad_params: dict, mapping: dict) -> list:
+    """Check all mapped parameters exist and match."""
+    errors = []
+    
+    for param in mapping['parameters']:
+        openscad_name = param['openscad_name']
+        
+        if openscad_name not in scad_params:
+            errors.append(f"Missing parameter: {openscad_name}")
+            continue
+        
+        # Check default value matches
+        expected = param['default']
+        actual = scad_params[openscad_name]['default']
+        
+        if expected != actual:
+            errors.append(
+                f"Default mismatch for {openscad_name}: "
+                f"expected {expected}, got {actual}"
+            )
+    
+    return errors
+```
+
+---
+
+## Phase 3: Geometry Implementation
+
+### Step 3.1: Coordinate System Transformation
+
+Most web 3D libraries (Three.js, Babylon.js) use Y-up coordinates. OpenSCAD uses Z-up.
+
+**Transformation Matrix:**
+
+```scad
+// Transform from Y-up to Z-up
+module y_up_to_z_up() {
+    rotate([90, 0, 0])
+        children();
+}
+
+// Or for individual points:
+// web_point = [x, y, z]  (Y-up)
+// openscad_point = [x, z, -y]  (Z-up)
+```
+
+### Step 3.2: Geometry Primitives
+
+Match web generator geometry exactly:
+
+**Spherical Cap (Dome)**
+
+```scad
+// Spherical cap formula: R = (r² + h²) / (2h)
+// where r = base radius, h = cap height
+module spherical_cap(base_radius, cap_height) {
+    R = (base_radius * base_radius + cap_height * cap_height) / (2 * cap_height);
+    center_z = cap_height - R;
+    
+    intersection() {
+        translate([0, 0, center_z])
+            sphere(r = R, $fn = 32);
+        
+        // Clip to cap region
+        translate([0, 0, R])
+            cube([R * 4, R * 4, R * 2], center = true);
+    }
+}
+```
+
+**Frustum (Truncated Cone)**
+
+```scad
+module frustum(base_r, top_r, height) {
+    cylinder(h = height, r1 = base_r, r2 = top_r, $fn = 32);
+}
+```
+
+### Step 3.3: Tessellation Matching
+
+Web generators often use specific segment counts. Match them:
+
+```scad
+// Document tessellation settings
+// Web generator uses: sphere segments=24, cylinder segments=32
+
+$fn = 32;  // Default for cylinders
+
+// For spheres, match web generator
+sphere_segments = 24;
+sphere(r = 10, $fn = sphere_segments);
+```
+
+### Step 3.4: Boolean Operations
+
+Order matters! Match the web generator's boolean operation sequence:
+
+```scad
+// Web generator: base → subtract holes → add features
+difference() {
+    union() {
+        base_shape();
+        added_features();
+    }
+    subtracted_holes();
+}
+```
+
+---
+
+## Phase 4: Test Framework Setup
+
+### Step 4.1: Install Dependencies
+
+Create `tests/requirements.txt`:
+
+```
+trimesh>=4.0.0
+numpy>=1.24.0
+scipy>=1.10.0
+pytest>=7.0.0
+pyyaml>=6.0
+jsonschema>=4.0.0
+playwright>=1.40.0
+```
+
+Install:
+
+```bash
+pip install -r tests/requirements.txt
+python -m playwright install chromium
+```
+
+### Step 4.2: OpenSCAD Runner
+
+Create `tests/openscad_runner.py`:
+
+```python
+"""OpenSCAD CLI wrapper for automated STL generation."""
+
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Optional
+
+class OpenSCADRunner:
+    def __init__(self, openscad_path: Optional[str] = None):
+        self.openscad_path = openscad_path or self._find_openscad()
+    
+    def _find_openscad(self) -> str:
+        """Auto-detect OpenSCAD executable."""
+        candidates = ['openscad', 'OpenSCAD']
+        for name in candidates:
+            path = shutil.which(name)
+            if path:
+                return path
+        raise FileNotFoundError("OpenSCAD not found")
+    
+    def generate_stl(
+        self,
+        scad_file: Path,
+        output_file: Path,
+        parameters: dict,
+        timeout: int = 300
+    ) -> bool:
+        """Generate STL from OpenSCAD file with parameters."""
+        
+        cmd = [self.openscad_path, '-o', str(output_file)]
+        
+        # Add parameters as -D flags
+        for name, value in parameters.items():
+            if isinstance(value, str):
+                cmd.extend(['-D', f'{name}="{value}"'])
+            else:
+                cmd.extend(['-D', f'{name}={value}'])
+        
+        cmd.append(str(scad_file))
+        
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=timeout
+        )
+        
+        return result.returncode == 0 and output_file.exists()
+```
+
+### Step 4.3: Mesh Comparison
+
+Create `tests/mesh_comparison.py`:
+
+```python
+"""Compare two STL meshes for geometric equivalence."""
+
+import trimesh
+import numpy as np
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class ComparisonResult:
+    passed: bool
+    volume_diff_pct: float
+    area_diff_pct: float
+    bbox_diff_mm: float
+    both_watertight: bool
+    details: dict
+
+class MeshComparator:
+    def __init__(self, config: dict):
+        self.tolerances = config.get('tolerances', {})
+    
+    def compare(
+        self,
+        reference_path: str,
+        test_path: str
+    ) -> ComparisonResult:
+        """Compare reference and test STL files."""
+        
+        ref_mesh = trimesh.load(reference_path)
+        test_mesh = trimesh.load(test_path)
+        
+        # Volume comparison
+        vol_diff = abs(ref_mesh.volume - test_mesh.volume)
+        vol_diff_pct = (vol_diff / ref_mesh.volume) * 100
+        
+        # Surface area comparison
+        area_diff = abs(ref_mesh.area - test_mesh.area)
+        area_diff_pct = (area_diff / ref_mesh.area) * 100
+        
+        # Bounding box comparison
+        ref_bbox = ref_mesh.bounds
+        test_bbox = test_mesh.bounds
+        bbox_diff = np.max(np.abs(ref_bbox - test_bbox))
+        
+        # Watertightness
+        both_watertight = ref_mesh.is_watertight and test_mesh.is_watertight
+        
+        # Check tolerances
+        vol_ok = vol_diff_pct <= self.tolerances.get('volume_percent', 1.0)
+        area_ok = area_diff_pct <= self.tolerances.get('area_percent', 0.5)
+        bbox_ok = bbox_diff <= self.tolerances.get('bbox_mm', 0.1)
+        
+        passed = vol_ok and area_ok and bbox_ok and both_watertight
+        
+        return ComparisonResult(
+            passed=passed,
+            volume_diff_pct=vol_diff_pct,
+            area_diff_pct=area_diff_pct,
+            bbox_diff_mm=bbox_diff,
+            both_watertight=both_watertight,
+            details={
+                'ref_volume': ref_mesh.volume,
+                'test_volume': test_mesh.volume,
+                'ref_area': ref_mesh.area,
+                'test_area': test_mesh.area,
+            }
+        )
+```
+
+### Step 4.4: Test Suite
+
+Create `tests/cross_platform_validation.py`:
+
+```python
+"""Cross-platform STL validation test suite."""
+
+import pytest
+import json
+from pathlib import Path
+
+from openscad_runner import OpenSCADRunner
+from mesh_comparison import MeshComparator
+
+FIXTURES_DIR = Path(__file__).parent / 'fixtures' / 'cross_platform'
+SCAD_FILE = Path(__file__).parent.parent / 'model.scad'
+
+def load_test_cases():
+    """Load test case definitions."""
+    with open(FIXTURES_DIR / 'test_cases.json') as f:
+        data = json.load(f)
+    return [tc['name'] for tc in data['test_cases']]
+
+@pytest.fixture
+def openscad_runner():
+    return OpenSCADRunner()
+
+@pytest.fixture
+def mesh_comparator(request):
+    config_path = request.config.getoption('--comparison-config')
+    with open(config_path) as f:
+        config = json.load(f)
+    return MeshComparator(config)
+
+@pytest.mark.parametrize('test_case', load_test_cases())
+def test_stl_validation(test_case, openscad_runner, mesh_comparator, tmp_path):
+    """Validate OpenSCAD output matches web reference."""
+    
+    fixture_dir = FIXTURES_DIR / test_case
+    
+    # Load parameters
+    with open(fixture_dir / 'params.json') as f:
+        params = json.load(f)
+    
+    # Generate OpenSCAD STL
+    output_stl = tmp_path / 'output.stl'
+    success = openscad_runner.generate_stl(
+        SCAD_FILE, output_stl, params
+    )
+    assert success, "OpenSCAD generation failed"
+    
+    # Compare to reference
+    reference_stl = fixture_dir / 'reference.stl'
+    result = mesh_comparator.compare(
+        str(reference_stl),
+        str(output_stl)
+    )
+    
+    assert result.passed, (
+        f"Mesh comparison failed:\n"
+        f"  Volume diff: {result.volume_diff_pct:.2f}%\n"
+        f"  Area diff: {result.area_diff_pct:.2f}%\n"
+        f"  Bbox diff: {result.bbox_diff_mm:.3f}mm"
+    )
+```
+
+---
+
+## Phase 5: Fixture Generation
+
+### Step 5.1: Web Fixture Generator (Playwright)
+
+Create `scripts/generate_web_fixtures.py`:
+
+```python
+"""Generate reference STL fixtures from web generator using Playwright."""
+
+import asyncio
+import json
+from pathlib import Path
+from playwright.async_api import async_playwright
+
+async def generate_fixture(
+    page,
+    test_case: dict,
+    output_dir: Path,
+    web_url: str
+):
+    """Generate single fixture from web UI."""
+    
+    await page.goto(web_url)
+    
+    # Fill in parameters (UPDATE SELECTORS FOR YOUR WEB UI)
+    for param, value in test_case['parameters'].items():
+        selector = f'[name="{param}"], #{param}'
+        element = page.locator(selector)
+        
+        if await element.count() > 0:
+            tag = await element.evaluate('el => el.tagName')
+            
+            if tag == 'SELECT':
+                await element.select_option(value)
+            else:
+                await element.fill(str(value))
+    
+    # Click generate/download button
+    async with page.expect_download() as download_info:
+        await page.click('button:has-text("Download")')
+    
+    download = await download_info.value
+    
+    # Save to fixture directory
+    fixture_dir = output_dir / test_case['name']
+    fixture_dir.mkdir(exist_ok=True)
+    
+    await download.save_as(fixture_dir / 'reference.stl')
+    
+    # Save parameters
+    with open(fixture_dir / 'params.json', 'w') as f:
+        json.dump(test_case['parameters'], f, indent=2)
+
+async def main(web_url: str, test_cases_file: Path, output_dir: Path):
+    """Generate all fixtures."""
+    
+    with open(test_cases_file) as f:
+        data = json.load(f)
+    
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        
+        for test_case in data['test_cases']:
+            print(f"Generating: {test_case['name']}")
+            await generate_fixture(page, test_case, output_dir, web_url)
+        
+        await browser.close()
+
+if __name__ == '__main__':
+    import argparse
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--web-url', required=True)
+    parser.add_argument('--test-cases', default='tests/fixtures/cross_platform/test_cases.json')
+    parser.add_argument('--output-dir', default='tests/fixtures/cross_platform')
+    
+    args = parser.parse_args()
+    
+    asyncio.run(main(
+        args.web_url,
+        Path(args.test_cases),
+        Path(args.output_dir)
+    ))
+```
+
+### Step 5.2: Test Cases Definition
+
+Create `tests/fixtures/cross_platform/test_cases.json`:
+
+```json
+{
+  "fixture_version": "1.0.0",
+  "web_generator_url": "https://your-web-generator.com",
+  "web_generator_commit": "abc123",
+  "last_updated": "2026-01-10",
+  
+  "test_cases": [
+    {
+      "name": "basic_cylinder",
+      "description": "Basic cylinder with default parameters",
+      "parameters": {
+        "shape_type": "Cylinder",
+        "width": 100,
+        "height": 50
+      },
+      "priority": "high"
+    },
+    {
+      "name": "custom_dimensions",
+      "description": "Cylinder with custom dimensions",
+      "parameters": {
+        "shape_type": "Cylinder",
+        "width": 75.5,
+        "height": 120
+      },
+      "priority": "medium"
+    }
+  ]
+}
+```
+
+### Step 5.3: Comparison Configuration
+
+Create `tests/compare_config.json` (baseline):
+
+```json
+{
+  "profile": "baseline",
+  "description": "Baseline tolerances for initial debugging",
+  
+  "tolerances": {
+    "volume_percent": 1.0,
+    "area_percent": 0.5,
+    "bbox_mm": 0.1,
+    "max_surface_deviation_mm": 0.05
+  },
+  
+  "required_checks": {
+    "volume": true,
+    "area": true,
+    "bbox": true,
+    "watertight": true
+  }
+}
+```
+
+Create `tests/compare_config_strict.json`:
+
+```json
+{
+  "profile": "strict",
+  "description": "Strict tolerances for CI quality gates",
+  
+  "tolerances": {
+    "volume_percent": 0.1,
+    "area_percent": 0.1,
+    "bbox_mm": 0.01,
+    "max_surface_deviation_mm": 0.02
+  },
+  
+  "required_checks": {
+    "volume": true,
+    "area": true,
+    "bbox": true,
+    "watertight": true
+  }
+}
+```
+
+---
+
+## Phase 6: Validation & Iteration
+
+### Step 6.1: Initial Validation Run
+
+```bash
+# Run with baseline tolerances first
+pytest tests/cross_platform_validation.py -v
+
+# Expect failures - document them
+pytest tests/cross_platform_validation.py -v > initial_results.txt 2>&1
+```
+
+### Step 6.2: Analyze Failures
+
+For each failing test:
+
+1. **Identify failure type**: Volume? Area? Bounding box?
+2. **Quantify difference**: How far off is it?
+3. **Isolate cause**: Which geometry primitive is wrong?
+4. **Compare visually**: Open both STLs in a mesh viewer
+
+### Step 6.3: Fix Geometry Issues
+
+Common issues and fixes:
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Volume too high | Extra geometry | Check boolean operations |
+| Volume too low | Missing geometry | Check all features added |
+| Area mismatch | Tessellation diff | Match segment counts |
+| Bbox mismatch | Coordinate system | Check Y-up vs Z-up |
+| Not watertight | Boolean errors | Increase $fn, check overlaps |
+
+### Step 6.4: Iterate Until Passing
+
+```bash
+# After fixes, run again
+pytest tests/cross_platform_validation.py -v
+
+# Once baseline passes, try strict
+pytest tests/cross_platform_validation.py \
+  --comparison-config=tests/compare_config_strict.json -v
+```
+
+---
+
+## Phase 7: CI/CD Integration
+
+### Step 7.1: GitHub Actions Workflow
+
+Create `.github/workflows/stl-validation.yml`:
+
+```yaml
+name: STL Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.scad'
+      - 'tests/**'
+  pull_request:
+    branches: [main]
+
+env:
+  CI: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install OpenSCAD
+        run: |
+          wget -q https://files.openscad.org/snapshots/OpenSCAD-2026.01.03-x86_64.AppImage -O openscad.AppImage
+          chmod +x openscad.AppImage
+          ./openscad.AppImage --appimage-extract
+          sudo mv squashfs-root /opt/openscad
+          sudo ln -sf /opt/openscad/AppRun /usr/local/bin/openscad
+      
+      - name: Install dependencies
+        run: pip install -r tests/requirements.txt
+      
+      - name: Run validation tests
+        run: pytest tests/cross_platform_validation.py -v
+```
+
+### Step 7.2: Git LFS for Fixtures
+
+STL files should be tracked with Git LFS:
+
+```bash
+# Install Git LFS
+git lfs install
+
+# Track STL files
+echo "*.stl filter=lfs diff=lfs merge=lfs -text" >> .gitattributes
+
+# Add and commit
+git add .gitattributes
+git add tests/fixtures/
+git commit -m "Add reference fixtures"
+```
+
+---
+
+## Best Practices
+
+### 1. Parameter Naming
+
+- Use descriptive names matching web UI labels
+- Document units (mm, degrees, etc.)
+- Provide sensible defaults
+
+### 2. Dropdown Menus
+
+- Use human-readable labels directly
+- Avoid `value:Label` format (causes duplicates)
+- Add hidden parameters for test system compatibility
+
+### 3. Geometry Precision
+
+- Match web generator's tessellation settings
+- Use explicit `$fn` values, not `$fa`/`$fs`
+- Document any intentional differences
+
+### 4. Test Coverage
+
+- Cover all parameter combinations (or representative subset)
+- Include edge cases (min/max values)
+- Add isolation tests for complex features
+
+### 5. Documentation
+
+- Document coordinate system transformations
+- Explain geometry formulas (spherical cap, etc.)
+- Keep parameter mapping up to date
+
+### 6. Version Control
+
+- Track fixture version in metadata
+- Record web generator commit hash
+- Document reasons for fixture regeneration
+
+---
+
+## Troubleshooting
+
+### "OpenSCAD not found"
+
+```bash
+# Check if installed
+which openscad
+
+# Set path explicitly
+export OPENSCAD_PATH=/path/to/openscad
+```
+
+### "Fixtures not found"
+
+```bash
+# Pull LFS files
+git lfs pull
+
+# Or regenerate
+python scripts/generate_web_fixtures.py --web-url https://...
+```
+
+### "Volume mismatch"
+
+1. Check boolean operation order
+2. Verify all geometry primitives match
+3. Compare tessellation settings
+
+### "Bounding box mismatch"
+
+1. Check coordinate system (Y-up vs Z-up)
+2. Verify centering/positioning
+3. Check for off-by-one errors in positioning
+
+### "Not watertight"
+
+1. Increase `$fn` for smoother curves
+2. Check for overlapping geometry
+3. Ensure boolean operations are clean
+
+---
+
+## Reference Implementation
+
+This guide is based on the Braille Cylinder STL Generator project:
+
+- **Repository**: `braille-stl-generator-openscad`
+- **Web Generator**: `braille-card-and-cylinder-stl-generator`
+
+Key files to study:
+
+1. `Braille_Card_And_Cylinder_STL_Generator.scad` - OpenSCAD implementation
+2. `tests/parameter_mapping.json` - Parameter mapping schema
+3. `tests/cross_platform_validation.py` - Test suite
+4. `scripts/generate_web_fixtures.py` - Fixture generator
+5. `.github/workflows/stl-validation.yml` - CI/CD workflow
+
+---
+
+## Conclusion
+
+Creating an OpenSCAD implementation that matches a web generator requires:
+
+1. **Thorough analysis** of the web generator's geometry
+2. **Precise parameter mapping** between platforms
+3. **Automated validation** to catch regressions
+4. **Continuous integration** to maintain parity
+
+By following this guide, you can create reliable, validated OpenSCAD implementations that produce geometrically equivalent output to web-based 3D generators.
+
+---
+
+**Document Version**: 1.0.0  
+**Last Updated**: 2026-01-10  
+**License**: PolyForm Noncommercial 1.0.0

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ There's a **Help** button inside the app that walks you through choosing what to
 
 ## OpenSCAD version
 
-Prefer working offline or want full parametric control? There's a standalone OpenSCAD version of this tool:
+Prefer working offline or want full parametric control? An OpenSCAD version of this tool is included in the [`OpenSCAD/`](OpenSCAD/) folder.
 
-[braille-stl-generator-openscad](https://github.com/BrennenJohnston/braille-stl-generator-openscad)
+- [`OpenSCAD/Braille_Card_And_Cylinder_STL_Generator.scad`](OpenSCAD/Braille_Card_And_Cylinder_STL_Generator.scad) — the main script (open this in [OpenSCAD](https://openscad.org/) and use the Customizer panel)
+- [`OpenSCAD/README.md`](OpenSCAD/README.md) — quick start, parameters, troubleshooting
+- [`OpenSCAD/PARAMETER_MAPPING.md`](OpenSCAD/PARAMETER_MAPPING.md) — how OpenSCAD parameters correspond to the web UI controls
+- [`OpenSCAD/docs/`](OpenSCAD/docs/) — coordinate system reference, web-to-OpenSCAD porting guide, testing notes
 
 The web app translates automatically; the OpenSCAD version needs you to translate manually (using [Branah.com](https://www.branah.com/braille-translator)), but it works without an internet connection and integrates with existing CAD workflows.
 


### PR DESCRIPTION
## Summary

Vendor the OpenSCAD version of the Braille STL Generator into this repository under `OpenSCAD/` so users can download and use the offline OpenSCAD workflow without going to a separate repo.

## What changed

- New `OpenSCAD/` directory with:
  - `Braille_Card_And_Cylinder_STL_Generator.scad` — the parametric script (open in OpenSCAD)
  - `README.md` — quick start, parameters, troubleshooting (with vendoring notice at top)
  - `PARAMETER_MAPPING.md` — OpenSCAD-to-web-UI parameter map
  - `LICENSE` — verified identical to root LICENSE (PolyForm Noncommercial 1.0.0)
  - `docs/WEB_TO_OPENSCAD_PORTING_GUIDE.md`
  - `docs/OPENSCAD_COORDINATE_SYSTEM_SPECIFICATIONS.md`
  - `docs/QUICK_START_TESTING.md`
- Removed `OpenSCAD/` from `.gitignore`
- Updated main `README.md` "OpenSCAD version" section to point to the local folder instead of the external repo

## What's NOT vendored (intentionally)

- `tests/` and binary STL fixtures (~30 reference STLs) — kept the download lightweight; users wanting the validation suite can find it at the [original snapshot](https://github.com/BrennenJohnston/braille-stl-generator-openscad)
- `scripts/` (validation/fixture generation tooling) — dev-only
- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` — already covered by the root repo's equivalents
- Project archives (`docs/archive/*`)

## Source

Files extracted byte-exact from `openscad-fork/main` using cmd-redirected `git show` to preserve UTF-8 and line endings. All 7 vendored files have sizes matching upstream blobs exactly.

## Test plan

- [x] All 7 vendored files have correct byte-exact size matching upstream blobs
- [x] `OpenSCAD/README.md` renders correctly (emoji, tables, fenced code intact)
- [x] Internal links in `OpenSCAD/README.md` point to vendored files; broken links to non-vendored `tests/` removed or redirected
- [x] Main `README.md` "OpenSCAD version" section links resolve to local files
- [x] `OpenSCAD/` no longer excluded by `.gitignore`
