### PR TITLE
chore(deps-dev): bump ruff to 0.15.2 and apply UP042 fixes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,7 +6,7 @@ replacing magic numbers and untyped dictionaries with explicit, validated struct
 """
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 
 from app.utils import get_logger
 
@@ -15,21 +15,21 @@ logger = get_logger(__name__)
 
 
 # Enums for typed models
-class ShapeType(str, Enum):
+class ShapeType(StrEnum):
     """Shape type for braille output."""
 
     CARD = 'card'
     CYLINDER = 'cylinder'
 
 
-class PlateType(str, Enum):
+class PlateType(StrEnum):
     """Plate type: positive (embossed) or negative (counter/recess)."""
 
     POSITIVE = 'positive'
     NEGATIVE = 'negative'
 
 
-class BrailleGrade(str, Enum):
+class BrailleGrade(StrEnum):
     """Braille grade: G1 (uncontracted) or G2 (contracted)."""
 
     G1 = 'g1'
@@ -44,7 +44,7 @@ class RecessShape(int, Enum):
     CONE = 2  # Frustum
 
 
-class PlacementMode(str, Enum):
+class PlacementMode(StrEnum):
     """Placement mode for braille text."""
 
     MANUAL = 'manual'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     # Development tools
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
-    "ruff==0.14.13",
+    "ruff==0.15.2",
     "mypy==1.19.1",
     "pre-commit==4.5.1",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,6 @@ manifold3d==3.3.2          # Boolean operations (not available on Vercel)
 # Development tools
 pytest==9.0.2
 pytest-cov==7.0.0
-ruff==0.14.13              # Linting and formatting
+ruff==0.15.2               # Linting and formatting
 mypy==1.19.1               # Type checking
 pre-commit==4.5.1          # Git hooks


### PR DESCRIPTION
## Summary

- Bumps `ruff` from `0.14.13` → `0.15.2` in [`pyproject.toml`](pyproject.toml) and [`requirements-dev.txt`](requirements-dev.txt).
- Fixes the four new `UP042` (replace-str-enum) findings in [`app/models.py`](app/models.py) by switching `ShapeType`, `PlateType`, `BrailleGrade`, and `PlacementMode` from `class X(str, Enum)` to `class X(StrEnum)` (`StrEnum` is available since Python 3.11; this project targets 3.12).
- `RecessShape(int, Enum)` is left untouched (`UP042` only fires on the `str, Enum` pattern in 0.15).

## Why this supersedes #55

PR #55 only bumped the ruff version pin. It failed CI in 33s on the `Lint with ruff` step because ruff 0.15 stabilized `UP042` inside this repo's `UP` selector. This branch contains both the version bump and the matching source fixes in a single commit.

## Verification (local, Python 3.13.5)

```
ruff 0.15.2
$ ruff check .
All checks passed!
$ ruff format --check .
23 files already formatted
$ pytest -q
24 passed in 0.33s
```

`ruff format --check .` was already clean against the 0.15 / 2026 formatter style — no formatter-driven source changes were needed.

## Test plan

- [ ] CI `backend-tests` job: `ruff check .` passes, `ruff format --check .` passes, `pytest` passes.
- [ ] CI `frontend-tests`, `e2e-tests`, `accessibility-tests` jobs: unchanged (no JS or runtime Python behavior change).

After merge, close #55 with a pointer to this PR.
