### PR TITLE
chore(deps): remove unused manifold-3d npm dependency

### DIFF
--- a/docs/development/OPTIONAL_MANIFOLD3D_PATH.md
+++ b/docs/development/OPTIONAL_MANIFOLD3D_PATH.md
@@ -1,5 +1,11 @@
 # Optional: Client-Side manifold3d Path
 
+> **Status (2026-05-26): Not currently implemented.** This document is a forward-looking design note, not a description of the production code path.
+>
+> The runtime today loads Manifold from a CDN (pinned to `manifold-3d@2.5.1` via `https://cdn.jsdelivr.net/npm/manifold-3d@2.5.1/manifold.js`, with `unpkg` as a CDN-to-CDN fallback) inside [`static/workers/csg-worker-manifold.js`](../../static/workers/csg-worker-manifold.js) and [`static/workers/csg-worker.js`](../../static/workers/csg-worker.js). There is **no bundler** in this project (no vite/webpack/esbuild/rollup config) and `manifold-3d` is **not listed in `package.json`** — Dependabot bumps to the npm package therefore have no runtime effect. See [#61](https://github.com/BrennenJohnston/braille-card-and-cylinder-stl-generator/pull/61) for context on why the npm dependency was removed.
+>
+> If you ever do want to vendor Manifold locally instead of fetching from CDN, the recipe in this document is the right starting point. The first step is restoring `manifold-3d` to `package.json`'s `dependencies`. The second step is to either set up a bundler (vite/webpack/esbuild) or to manually copy `node_modules/manifold-3d/manifold.{js,wasm}` into `static/vendor/manifold-3d/` (mirroring how `static/vendor/three-bvh-csg/` and `static/vendor/three-mesh-bvh/` are vendored today). The third step is to update the URLs inside the two CSG workers and the example in `docs/specifications/STL_EXPORT_AND_DOWNLOAD_SPECIFICATIONS.md`.
+
 This document outlines how to add client-side manifold3d (WASM) as an additional CSG engine for watertight mesh output, at the cost of a larger bundle size (~2-3 MB).
 
 ## Why Add manifold3d?

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "liblouis": "^0.4.0",
-        "manifold-3d": "^2.5.1",
         "three-bvh-csg": "^0.0.18",
         "three-mesh-bvh": "^0.9.10"
       },
@@ -910,12 +909,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/manifold-3d": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/manifold-3d/-/manifold-3d-2.5.1.tgz",
-      "integrity": "sha512-pfyfJo4yEIMqniFxsWfxKJAcOsN/3LoIWLrPHKAyZNwAh+i/gy+8NPmBAC80XfUm+uhGTXLhAtoDcwi282gbTQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   ],
   "dependencies": {
     "liblouis": "^0.4.0",
-    "manifold-3d": "^2.5.1",
     "three-bvh-csg": "^0.0.18",
     "three-mesh-bvh": "^0.9.10"
   },


### PR DESCRIPTION
## Summary

- Removes the unused `manifold-3d` entry from [`package.json`](package.json) and regenerates [`package-lock.json`](package-lock.json).
- Adds a forward-looking "Status (2026-05-26)" header to [`docs/development/OPTIONAL_MANIFOLD3D_PATH.md`](docs/development/OPTIONAL_MANIFOLD3D_PATH.md) explaining that the local-vendoring path is not currently implemented and pointing future contributors at the actual upgrade surface (the CDN URL strings inside the workers).

## Why

The npm `manifold-3d` package is decorative — verified that it is **never imported** and **never bundled**:

- No bundler config exists in this repo (no vite/webpack/esbuild/rollup configs; `vitest.config.js` only configures the test runner).
- No `import` or `require` of `manifold-3d` exists anywhere in `.js` / `.html` / `.json` / `.mjs` / `.cjs` / `.ts` files.
- Both CSG workers load Manifold from a hardcoded CDN URL pinned to `manifold-3d@2.5.1`:
  - [`static/workers/csg-worker-manifold.js`](static/workers/csg-worker-manifold.js) lines 36-39 (active worker for cylinders)
  - [`static/workers/csg-worker.js`](static/workers/csg-worker.js) lines 83-86 (legacy worker, uses Manifold only for optional mesh repair)
- The "fallback" path is **CDN-to-CDN** (jsdelivr → unpkg), not CDN-to-npm.
- [`static/vendor/`](static/vendor/) contains `three-bvh-csg` and `three-mesh-bvh` only — no `manifold-3d` subdir.

So bumping the npm pin (e.g. #61, `2.5.1 → 3.4.1`) changes nothing that the user actually runs at runtime. Removing the unused dep eliminates the version-drift confusion and stops Dependabot from generating no-op major-version bumps.

If we ever want to actually upgrade the Manifold runtime, that's a separate change touching the four CDN URL strings (two each in the workers above) plus the example in [`docs/specifications/STL_EXPORT_AND_DOWNLOAD_SPECIFICATIONS.md`](docs/specifications/STL_EXPORT_AND_DOWNLOAD_SPECIFICATIONS.md), and requires a manual cylinder STL test in the browser.

## Closes

Closes #61.

## Verification

```
$ npm install
added 8 packages, removed 6 packages, changed 22 packages, and audited 53 packages in 2s
found 0 vulnerabilities
$ npm test
Test Files  1 passed (1)
     Tests  2 passed (2)
```

`npm install` removes only `manifold-3d` from `package-lock.json` (manifold-3d 2.5.1 has no transitive deps to orphan). The "added 8 / removed 6" counts above are npm's running tallies across the lockfile sync; the actual diff is just the `manifold-3d` entry being dropped.

## Test plan

- [ ] CI `frontend-tests` job: Vitest passes (no JS source change).
- [ ] CI `e2e-tests` job: Playwright spins up the Flask app and exercises cylinder generation end-to-end. Cylinder generation goes through `csg-worker-manifold.js` which loads from CDN — unaffected by the npm change. **If E2E passes, that is conclusive evidence nothing was wired to the npm copy.**
- [ ] CI `backend-tests` and `accessibility-tests` jobs: unchanged.

After merge, leave a closing comment on #61 with the rationale.
