### PR TITLE
chore(backend): remove unused SECRET_KEY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open [http://localhost:5001](http://localhost:5001) in your browser.
 
 That's it. No Redis, no blob storage, no API keys to manage. The server just serves static files and a lightweight JSON endpoint — all the heavy geometry work happens in your browser.
 
-You can optionally set `SECRET_KEY` and `PRODUCTION_DOMAIN` as environment variables, but neither is required. See [Environment Variables](docs/security/ENVIRONMENT_VARIABLES.md) if you're curious.
+You can optionally set `PRODUCTION_DOMAIN` as an environment variable, but it's not required. See [Environment Variables](docs/security/ENVIRONMENT_VARIABLES.md) if you're curious.
 
 ## How to use it
 

--- a/backend.py
+++ b/backend.py
@@ -84,18 +84,6 @@ CORS(app, origins=allowed_origins, supports_credentials=cors_supports_credential
 # Typical requests: Braille text (~10KB), Geometry spec (~50KB)
 app.config['MAX_CONTENT_LENGTH'] = 100 * 1024  # 100KB max (reduced from 1MB)
 
-# SECRET_KEY configuration - optional for stateless backend
-SECRET_KEY = os.environ.get('SECRET_KEY')
-if not SECRET_KEY:
-    if os.environ.get('FLASK_ENV') == 'development':
-        SECRET_KEY = 'dev-key-change-in-production'
-        logger.warning('Using insecure development SECRET_KEY - DO NOT use in production!')
-    else:
-        # For stateless backend, SECRET_KEY is optional but recommended
-        SECRET_KEY = 'stateless-backend-no-sessions'
-        logger.warning('SECRET_KEY not set - using placeholder (backend is stateless)')
-app.config['SECRET_KEY'] = SECRET_KEY
-
 
 # Security headers middleware
 @app.after_request

--- a/docs/deployment/DEPLOYMENT_CHECKLIST.md
+++ b/docs/deployment/DEPLOYMENT_CHECKLIST.md
@@ -24,16 +24,9 @@ No environment variables are required. Vercel auto-detects Python from `requirem
 
 | Variable | Purpose |
 |----------|---------|
-| `SECRET_KEY` | Flask session key (backend is stateless, so this is optional) |
 | `FLASK_ENV` | Set to `production` for strict security mode |
 | `PRODUCTION_DOMAIN` | Your domain for CORS (Vercel domains are allowed by default) |
 | `LOG_LEVEL` | Logging verbosity (default: INFO) |
-
-Generate a secret key if you want one:
-
-```bash
-python -c "import secrets; print(secrets.token_hex(32))"
-```
 
 ## Post-deployment testing
 

--- a/docs/deployment/DEPLOYMENT_COMPLETE.md
+++ b/docs/deployment/DEPLOYMENT_COMPLETE.md
@@ -136,7 +136,6 @@ REDIS_URL=redis://your-redis-url
 ### For Security
 ```bash
 FLASK_ENV=production
-SECRET_KEY=your-secret-key-here
 ```
 
 ---

--- a/docs/deployment/DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/deployment/DEPLOYMENT_READINESS_CHECKLIST.md
@@ -117,7 +117,6 @@ REDIS_URL=redis://your-redis-url
 # Optional - for production
 FLASK_ENV=production
 LOG_LEVEL=INFO
-SECRET_KEY=your-secret-key-here
 ```
 
 ### Vercel Configuration

--- a/docs/deployment/VERCEL_OPTIMIZATION_ROADMAP.md
+++ b/docs/deployment/VERCEL_OPTIMIZATION_ROADMAP.md
@@ -197,15 +197,11 @@ Implementation:
 
 **Optional (recommended for production):**
 
-1. **SECRET_KEY** (Flask)
-   - Generate: `python -c "import secrets; print(secrets.token_hex(32))"`
-   - Used for: Flask session security (optional for stateless backend)
-
-2. **PRODUCTION_DOMAIN** (CORS)
+1. **PRODUCTION_DOMAIN** (CORS)
    - Format: `https://your-domain.vercel.app`
    - Used for: CORS origin validation
 
-3. **FLASK_ENV** (Environment)
+2. **FLASK_ENV** (Environment)
    - Value: `production` or `development`
    - Used for: Debug mode control
 
@@ -226,10 +222,9 @@ Implementation:
    - Format: `rediss://default:<password>@<host>:<port>`
    - Used for: Rate limiting
 
-3. **SECRET_KEY** (Flask)
-   - Still optional but recommended
-   - Generate: Random string for session security
-   - Used for: Flask session management
+~~3. **SECRET_KEY** (Flask)~~
+   - **REMOVED** - Backend is stateless; no sessions or signed cookies in use
+   - Was used for: Flask session management
 
 ## Testing Guide
 

--- a/docs/development/CODEBASE_AUDIT_AND_RENOVATION_PLAN.md
+++ b/docs/development/CODEBASE_AUDIT_AND_RENOVATION_PLAN.md
@@ -249,7 +249,7 @@ enormous-caribou-11905.upstash.io:6379. Device or resource busy.
 | Variable | Status | Purpose |
 |----------|--------|---------|
 | `REDIS_URL` | SET (broken) | Points to archived Upstash Redis |
-| `SECRET_KEY` | ? | Flask session key |
+| `SECRET_KEY` | REMOVED | Flask session key (backend is stateless; no longer used) |
 | `PRODUCTION_DOMAIN` | NOT SET | CORS configuration |
 | `BLOB_STORE_WRITE_TOKEN` | ? | Vercel Blob upload |
 | `BLOB_PUBLIC_BASE_URL` | ? | Blob CDN URL |
@@ -507,7 +507,6 @@ This ensures the app works even if someone accidentally sets `REDIS_URL`.
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
-| `SECRET_KEY` | (generate with `python -c "import secrets; print(secrets.token_hex(32))"`) | Flask session security |
 | `PRODUCTION_DOMAIN` | Your Vercel domain (e.g., `https://your-app.vercel.app`) | CORS configuration |
 | `FLASK_ENV` | `production` | Disable debug mode |
 
@@ -584,7 +583,7 @@ This ensures the app works even if someone accidentally sets `REDIS_URL`.
 - [ ] Remove `/lookup_stl` endpoint
 - [ ] Remove `/debug/blob_upload` endpoint
 - [ ] Update `requirements.txt` to remove `redis` and `requests`
-- [ ] Set `SECRET_KEY` and `PRODUCTION_DOMAIN` in Vercel
+- [ ] Remove `SECRET_KEY` and set `PRODUCTION_DOMAIN`-only setup in Vercel
 
 ### Medium-term (This Month)
 

--- a/docs/security/ENVIRONMENT_VARIABLES.md
+++ b/docs/security/ENVIRONMENT_VARIABLES.md
@@ -9,20 +9,11 @@ For most deployments, you don't need to set anything. The app works out of the b
 If you want tighter security, set these:
 
 ```bash
-SECRET_KEY=<random-hex-string>
 FLASK_ENV=production
 PRODUCTION_DOMAIN=https://your-domain.vercel.app
 ```
 
 ## Variable reference
-
-### SECRET_KEY
-
-Flask session signing key. The backend is stateless and doesn't use sessions, so this is optional. Set it for defense-in-depth if you want.
-
-```bash
-python -c "import secrets; print(secrets.token_hex(32))"
-```
 
 ### FLASK_ENV
 
@@ -57,12 +48,14 @@ If you're migrating from v1.x, remove these from your Vercel config:
 - `BLOB_DIRECT_UPLOAD_URL`, `BLOB_API_BASE_URL`, `BLOB_CACHE_MAX_AGE`, `BLOB_URL_TTL_SEC`, `BLOB_STORE_ID`
 - `ENABLE_DEBUG_ENDPOINTS` — debug endpoints now return 410 Gone
 - `FORCE_CLIENT_CSG` — client-side CSG is the only method
+- `SECRET_KEY` — backend is stateless, no sessions or signed cookies in use
 
 ```bash
 vercel env rm REDIS_URL production
 vercel env rm BLOB_STORE_WRITE_TOKEN production
 vercel env rm BLOB_READ_WRITE_TOKEN production
 vercel env rm BLOB_PUBLIC_BASE_URL production
+vercel env rm SECRET_KEY production
 ```
 
 ## Troubleshooting
@@ -74,7 +67,6 @@ vercel env rm BLOB_PUBLIC_BASE_URL production
 ## Setting variables in Vercel
 
 ```bash
-vercel env add SECRET_KEY production
 vercel env add PRODUCTION_DOMAIN production
 ```
 


### PR DESCRIPTION
## Summary

- Removes the dead `SECRET_KEY` config block from `backend.py`. The backend is stateless and uses no Flask sessions, CSRF tokens, or signed cookies, so the value was never read.
- Updates `README.md`, deployment docs, and security docs so `SECRET_KEY` is no longer listed as a recognized environment variable.
- Adds a migration note for existing Vercel deployments to run `vercel env rm SECRET_KEY`.

## Test plan

- [x] CI checks passing on `develop`
- [x] Manual / e2e tests passing
- [x] Confirm Vercel preview build succeeds against this PR
- [ ] After merge, run `vercel env rm SECRET_KEY` against the production project to clean up the unused env var
