### PR TITLE
docs: point web app links at the new Vercel deployment, re-vendor OpenSCAD v2.4.1

### DIFF
--- a/OpenSCAD/Braille_Cylinder_STL_Generator.scad
+++ b/OpenSCAD/Braille_Cylinder_STL_Generator.scad
@@ -85,7 +85,7 @@
 // =============================================================================
 //  [1] Web-based Generator (with automatic translation): 
 //      https://github.com/BrennenJohnston/braille-cylinder-stl-generator
-//      https://braille-card-and-cylinder-stl-gener.vercel.app
+//      https://braille-cylinder-stl-generator.vercel.app
 //  [2] Branah Braille Translator: https://www.branah.com/braille-translator
 //  [3] BANA — Size and Spacing: https://brailleauthority.org/size-and-spacing-braille-characters
 //  [4] NLS — Specification 800: https://www.loc.gov/nls/

--- a/OpenSCAD/PARAMETER_MAPPING.md
+++ b/OpenSCAD/PARAMETER_MAPPING.md
@@ -7,12 +7,14 @@ This document maps the OpenSCAD customizer parameters to the web-based braille g
 ## Overview
 
 The OpenSCAD version has been updated to match the web-based generator's UI parameters. The only differences are:
-1. OpenSCAD requires **pre-translated Unicode braille** characters (no automatic translation)
+1. OpenSCAD requires **pre-translated Unicode braille** characters (no automatic translation). The web app can now take pre-translated braille too — it has a Braille (Unicode) field that is used verbatim — so this is a one-way gap: translation is web-only, direct braille input works in both.
 2. OpenSCAD is **cylinder-only** (card support removed)
 
 ## Translation Workflow
 
-1. **Web App**: Automatic translation using Liblouis (Grade 1 or Grade 2)
+1. **Web App**: Automatic translation using Liblouis (Grade 1 or Grade 2), or
+   paste pre-translated braille into its Braille (Unicode) field, which is used
+   verbatim — the same workflow as below
 2. **OpenSCAD**: Manual translation required at https://www.branah.com/braille-translator
    - User must select Grade 1 or Grade 2 manually
    - Copy Unicode braille output
@@ -36,17 +38,27 @@ The OpenSCAD version has been updated to match the web-based generator's UI para
 
 ### Indicator Mode
 
-Every parameter in this section is OpenSCAD-only — the web app has no tactile
-indicator mode, so all six map to `"web_api_name": null`.
+This mode originated here and the web app has since ported it, so every
+parameter below now has a web equivalent under the same name. The web app's
+runtime settings field names are identical; only the enum casing differs
+(`"Visual"`/`"Tactile"` here, `visual`/`tactile` on the wire). In
+`settings.schema.json` they live under `indicators.*`, and the web UI presents
+them as **Row Indicator Style** plus a **Tactile Indicator Dimensions** group in
+Expert Mode.
 
-| OpenSCAD Parameter | Default | Range / Values | Notes |
-|--------------------|---------|----------------|-------|
-| `indicator_mode` | `"Visual"` | `"Visual"`, `"Tactile"` | `Visual` = recessed marker cells at the start of each row (current behavior). `Tactile` = raised arrow on the emboss plate + matching recess on the counter plate, in the seam gap. See Note 3. |
-| `tactile_indicator_width` | 4.0 mm | 2–10 mm | Indicator width around the cylinder |
-| `tactile_indicator_length` | 5.0 mm | 2–15 mm | Indicator length along the cylinder axis; the default matches the 5 mm braille dot field height |
-| `tactile_indicator_raise` | 0.8 mm | 0–2 mm | How far the emboss arrow stands proud. Kept below the braille dot height so the dots carry the rolling pressure |
-| `tactile_recess_clearance` | 0.2 mm | 0–1 mm | Outline margin around the counter recess |
-| `tactile_recess_extra_depth` | 0.2 mm | 0–1 mm | Counter recess depth beyond the raise; 0 = exact same-depth nesting |
+| OpenSCAD Parameter | `web_api_name` | Default | Range / Values | Notes |
+|--------------------|----------------|---------|----------------|-------|
+| `indicator_mode` | `indicator_mode` | `"Visual"` | `"Visual"`, `"Tactile"` | `Visual` = recessed marker cells at the start of each row (current behavior). `Tactile` = raised arrow on the emboss plate + matching recess on the counter plate, in the seam gap. See Note 3. |
+| `tactile_indicator_width` | `tactile_indicator_width` | 4.0 mm | 2–10 mm | Indicator width around the cylinder |
+| `tactile_indicator_length` | `tactile_indicator_length` | 5.0 mm | 2–15 mm | Indicator length along the cylinder axis; the default matches the 5 mm braille dot field height |
+| `tactile_indicator_raise` | `tactile_indicator_raise` | 0.8 mm | 0–2 mm | How far the emboss arrow stands proud. Kept below the braille dot height so the dots carry the rolling pressure |
+| `tactile_recess_clearance` | `tactile_recess_clearance` | 0.2 mm | 0–1 mm | Outline margin around the counter recess |
+| `tactile_recess_extra_depth` | `tactile_recess_extra_depth` | 0.2 mm | 0–1 mm | Counter recess depth beyond the raise; 0 = exact same-depth nesting |
+
+Defaults are asserted equal on the web side
+(`tests/test_smoke.py::test_tactile_settings_defaults_match_openscad`), so the
+two generators produce the same arrow. Change a default here and that test fails
+there — deliberately.
 
 The five tactile sliders are **not** preset-driven — same policy as
 `grid_columns`. The paper-thickness presets describe paper and dot geometry;
@@ -293,7 +305,7 @@ All default values match the web-based generator's defaults (0.4mm paper preset 
 
 ## References
 
-- Web-based Generator: https://braille-card-and-cylinder-stl-gener.vercel.app
+- Web-based Generator: https://braille-cylinder-stl-generator.vercel.app
 - Web App Source: https://github.com/BrennenJohnston/braille-cylinder-stl-generator
 - OpenSCAD Version: https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad
 - Branah Braille Translator: https://www.branah.com/braille-translator

--- a/OpenSCAD/README.md
+++ b/OpenSCAD/README.md
@@ -5,8 +5,8 @@
 > | | |
 > |---|---|
 > | **Canonical repo** | [BrennenJohnston/braille-cylinder-stl-generator-openscad](https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad) |
-> | **Vendored from** | tag `v2.4.0` (commit `808d16b`, released 2026-07-27) |
-> | **Copied on** | 2026-07-27 |
+> | **Vendored from** | tag `v2.4.1` (commit `f31c101`, released 2026-07-29) |
+> | **Copied on** | 2026-07-29 |
 > | **Machine-readable provenance** | [`VENDORED.json`](VENDORED.json) |
 >
 > The standalone repo **is** the active home for this program: it holds the

--- a/OpenSCAD/README.md
+++ b/OpenSCAD/README.md
@@ -43,7 +43,7 @@ Parametric Model Maker. See [`docs/MAKERWORLD_QUICK_START.md`](docs/MAKERWORLD_Q
 
 | Version | Link | Use case |
 |---------|------|----------|
-| **Web app** | [braille-card-and-cylinder-stl-gener.vercel.app](https://braille-card-and-cylinder-stl-gener.vercel.app) | Browser-based, automatic translation |
+| **Web app** | [braille-cylinder-stl-generator.vercel.app](https://braille-cylinder-stl-generator.vercel.app) | Browser-based, automatic translation |
 | **OpenSCAD (canonical)** | [braille-cylinder-stl-generator-openscad](https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad) | Offline use, full parametric control, tests |
 | **Web app source** | [braille-cylinder-stl-generator](https://github.com/BrennenJohnston/braille-cylinder-stl-generator) | This repository |
 
@@ -201,7 +201,7 @@ Issues with the web app, or with this vendored copy being stale, belong
 
 ## References
 
-1. Web generator: <https://braille-card-and-cylinder-stl-gener.vercel.app>
+1. Web generator: <https://braille-cylinder-stl-generator.vercel.app>
 2. Branah translator: <https://www.branah.com/braille-translator>
 3. BANA size and spacing: <https://brailleauthority.org/size-and-spacing-braille-characters>
 4. NLS Specification 800: <https://www.loc.gov/nls/>

--- a/OpenSCAD/VENDORED.json
+++ b/OpenSCAD/VENDORED.json
@@ -1,15 +1,15 @@
 {
   "$comment": "Provenance for the vendored OpenSCAD copy. Every file below is copied verbatim from the upstream repository at the recorded tag. Edit them upstream, never here. tests/test_vendored_openscad.py fails if the .scad hash drifts from this record.",
   "upstream_repo": "https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad",
-  "upstream_tag": "v2.4.0",
-  "upstream_commit": "808d16bedafdc9d5f62cdc1f7a24c48419e87a5e",
-  "upstream_release_date": "2026-07-27",
-  "vendored_on": "2026-07-27",
+  "upstream_tag": "v2.4.1",
+  "upstream_commit": "f31c101356963b4b0d4b12ccae3934ec9dd1aa5c",
+  "upstream_release_date": "2026-07-29",
+  "vendored_on": "2026-07-29",
   "canonical": "upstream",
   "files": {
     "Braille_Cylinder_STL_Generator.scad": {
       "upstream_path": "makerworld/Braille_Cylinder_STL_Generator_MakerWorld_v2.scad",
-      "sha256": "c83b9295dc641d36bdad7dbc134f82f324256803d2c6a810e18df188b9ba8196",
+      "sha256": "d10c617f7d030e1e0a788f0492fbcec5c6fd2a34e562b3ffacb9b68c42dbed46",
       "note": "The MakerWorld single-file build is vendored rather than the dual-file desktop build, so the download is self-contained (no include <presets.scad>). Renamed on copy: this repo ships one file, so the _MakerWorld_v2 suffix would only confuse."
     },
     "LICENSE": { "upstream_path": "LICENSE" },

--- a/OpenSCAD/docs/MAKERWORLD_QUICK_START.md
+++ b/OpenSCAD/docs/MAKERWORLD_QUICK_START.md
@@ -61,9 +61,21 @@ needed for the whole number. For example, `206.616.7678` translates to:
 
 > `⠼⠃⠚⠋⠲⠋⠁⠋⠲⠛⠋⠛⠓` — exactly **13 cells**, which fits the default row.
 
-Some online translators repeat the number sign after each period. That output
-is non-standard and wastes cells — if your translation shows more than one
-`⠼` in a phone number, it likely will not fit.
+**Why the hyphens have to go.** A period keeps numeric mode, but a **hyphen or
+parenthesis ends it**, so every hyphen-separated group needs a fresh number
+sign. `206-543-4779` translates to:
+
+> `⠼⠃⠚⠋⠤⠼⠑⠙⠉⠤⠼⠙⠛⠛⠊` — **15 cells** with three `⠼`, which will not fit.
+
+That is correct UEB, not a translator bug: there is no setting anywhere that
+removes those signs. Retype the number with periods and it drops to 13 cells, or
+delete the extra cells by hand before pasting.
+
+Separately, some online translators repeat the number sign after each *period*
+too. That output is non-standard and wastes cells. So if your translation shows
+more than one `⠼` in a phone number, check which cause you have: hyphens in the
+input (retype with periods) or a translator adding signs after periods (switch
+translators).
 
 **Splitting a long number across two rows:** divide after a period and begin
 the next row with a fresh number sign:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ and containers.
 
 ## Quick start
 
+### Using the hosted app
+
+Open <https://braille-cylinder-stl-generator.vercel.app> — nothing to install.
+
 ### Running locally
 
 ```bash

--- a/docs/deployment/DEPLOYMENT_COMPLETE.md
+++ b/docs/deployment/DEPLOYMENT_COMPLETE.md
@@ -34,9 +34,10 @@
 
 ### Vercel Dashboard
 1. Go to your Vercel dashboard
-2. Find your project: `braille-card-and-cylinder-stl-generator` (the Vercel
-   project keeps its original name so the deployed URL stays valid; the GitHub
-   repo is now `braille-cylinder-stl-generator`)
+2. Find your project: `braille-cylinder-stl-generator`, deployed at
+   <https://braille-cylinder-stl-generator.vercel.app>. The original project
+   (`braille-card-and-cylinder-stl-gener.vercel.app`) predates the repo rename
+   and is no longer the deployment target.
 3. Watch the deployment progress
 4. Check build logs for any issues
 
@@ -53,13 +54,13 @@
 
 #### 1. Health Check
 ```
-https://your-app.vercel.app/health
+https://braille-cylinder-stl-generator.vercel.app/health
 ```
 **Expected:** `{"status": "ok", "message": "Vercel backend is running"}`
 
 #### 2. Liblouis Tables
 ```
-https://your-app.vercel.app/liblouis/tables
+https://braille-cylinder-stl-generator.vercel.app/liblouis/tables
 ```
 **Expected:** JSON with list of translation tables
 

--- a/docs/security/ENVIRONMENT_VARIABLES.md
+++ b/docs/security/ENVIRONMENT_VARIABLES.md
@@ -10,7 +10,7 @@ If you want tighter security, set these:
 
 ```bash
 FLASK_ENV=production
-PRODUCTION_DOMAIN=https://your-domain.vercel.app
+PRODUCTION_DOMAIN=https://braille-cylinder-stl-generator.vercel.app
 ```
 
 ## Variable reference
@@ -27,7 +27,7 @@ PRODUCTION_DOMAIN=https://your-domain.vercel.app
 Your production URL for CORS. Include the protocol (`https://`), no trailing slash. If not set, the app logs a warning and allows all origins.
 
 ```bash
-PRODUCTION_DOMAIN=https://braille-generator.vercel.app
+PRODUCTION_DOMAIN=https://braille-cylinder-stl-generator.vercel.app
 ```
 
 ### LOG_LEVEL


### PR DESCRIPTION
## Summary

The repo rename left the old Vercel project behind, so `braille-card-and-cylinder-stl-gener.vercel.app` is no longer the deployment that receives updates. The app now lives at <https://braille-cylinder-stl-generator.vercel.app>, and every reference to it across this repo (and the three sibling repos) now points there.

- **Docs** (`ca1a3a9`): updated the web app URL in `OpenSCAD/README.md`, `docs/deployment/DEPLOYMENT_COMPLETE.md`, and `docs/security/ENVIRONMENT_VARIABLES.md`. `DEPLOYMENT_COMPLETE.md` had claimed the Vercel project `keeps its original name so the deployed URL stays valid`, which is no longer true, so that note now names the current project and marks the old one as obsolete. Also added a hosted-app link to `README.md`, which had none.
- **Re-vendor** (`0126a4a`): the vendored OpenSCAD copy carried the old URL in a hash-guarded file, so the fix went upstream first and was released as [v2.4.1](https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad/releases/tag/v2.4.1). This bumps `OpenSCAD/` from v2.4.0 to v2.4.1: byte-exact copies of the MakerWorld build and two changed docs, the one documented local edit re-applied to `PARAMETER_MAPPING.md`, and `VENDORED.json` / the README banner updated to tag `v2.4.1`, commit `f31c101`, hash `d10c617f`.

No production behavior changes: `public/index.html`, `backend.py`, and all geometry code are untouched.

## Verification already done

The new deployment was compared against the old one rather than eyeballed:

- Served HTML is SHA-256 identical to local `main` (after CRLF/LF normalization)
- `POST /geometry_spec` returns a byte-identical cylinder response
- `/liblouis/tables` is hash-identical, 353 tables
- Tactile indicator mode is present in the deployed backend
- Security headers (CSP, HSTS, X-Frame-Options, Referrer-Policy) all present

## Test plan

- [x] `pytest` — 38 passed, including `tests/test_vendored_openscad.py` hash and provenance guards
- [x] Vendored `.scad` diff is exactly one line (the URL); `git diff --check` clean
- [x] Upstream `test_makerworld_sync.py` + source guards pass at v2.4.1
- [ ] Confirm the Vercel production deploy triggers on merge
- [ ] Set `PRODUCTION_DOMAIN=https://braille-cylinder-stl-generator.vercel.app` in the new Vercel project (CORS currently falls back to reflecting any origin)