### PR TITLE
chore(openscad): re-vendor the offline copy from upstream v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/e2e/brailleField.spec.ts` and `tests/e2e/tactileIndicator.spec.ts` — end-to-end coverage asserting on the payload actually sent to `/geometry_spec`, so the "used verbatim" and column-arithmetic contracts cannot regress silently.
 
 ### Changed
+- **Vendored OpenSCAD copy refreshed to upstream v2.5.0** (was v2.4.1). The offline
+  download in `OpenSCAD/` now carries `Line_5`–`Line_10`, closing a gap where the
+  Customizer's `grid_rows` slider allowed up to 10 rows but only four text fields
+  existed — the web app has grown its line list dynamically all along, so the offline
+  copy was the odd one out. `Line_9` and `Line_10` are in a separate
+  `[More Braille Lines (Advanced)]` tab because OpenSCAD cannot add fields on demand.
+  Upstream also added a `TOO MANY LINES: n/grid_rows` warning for braille typed past
+  the row limit, which previously disappeared from the exported STL with nothing to
+  say so; the web app blocks that case before generation instead. `VENDORED.json`,
+  the three changed files' hashes, and `OpenSCAD/README.md` are updated together, so
+  `tests/test_vendored_openscad.py` still pins the copy to a resolvable release.
 - **The default translation is now English (UEB) contracted, grade 2.** BANA's *Guidelines for Brailling Business Cards* (approved March 2024) tells transcribers to "Follow *The Rules of Unified English Braille*" and transcribes all nine of its worked examples in contracted UEB, so uncontracted was never the BANA-aligned choice — and contractions buy back cells on a 13-cell row, which is the constraint the whole guide is about. `en-ueb-g2.ctb` is now the selected option, the value every fallback in `public/index.html` resolves to (via a single `DEFAULT_LANGUAGE_TABLE` constant), the per-line default in manual mode, the Reset-to-defaults value, the liblouis worker's fallback when no table is named, and the documented `text.default_language` default in `settings.schema.json`. The help text, the Business Card Guide, the Cylinder Guide, the in-app help panels, and the language/translation specifications were all rewritten to match, including the "what to type" example hints that used to be labelled Grade 1.
 - **A saved language choice now survives a reload.** The page used to overwrite the restored `braille_prefs_language_table` value with the hard default on every load, so changing tables never stuck past a refresh. The default is now the first-run value only.
 - **The 3D preview is matte instead of glossy.** Shininess drops from 200 to 30 (standard themes) and from 300 with a white specular to 60 with `#333333` (high contrast), matching how PrusaSlicer, Cura, and MeshLab present an STL. The old values threw broad highlights across the plate that swallowed the dot geometry the preview exists to show; the three-point lighting carries the form instead, and the high-contrast cyan-on-black look is unchanged apart from losing the blown-out mirror. The Contrast stepper's shininess offsets were rescaled from `-40 … +220` to `-15 … +60` to suit the new base, and the `Math.max(50, …)` floor that would have defeated it is gone. Brightness levels are untouched. The material is now defined once in `STL_MATERIAL_SETTINGS` rather than duplicated across three call sites.

--- a/OpenSCAD/Braille_Cylinder_STL_Generator.scad
+++ b/OpenSCAD/Braille_Cylinder_STL_Generator.scad
@@ -57,10 +57,14 @@
 // =============================================================================
 //  1. Translate your text at https://www.branah.com/braille-translator
 //  2. Paste pre-translated braille into Line_1, Line_2, etc.
-//  3. Choose plate_type: Embossing Plate or Counter Plate
-//  4. Choose dot_shape: Rounded or Cone (affects both plates)
-//  5. Adjust dimensions in Expert Mode if needed
-//  6. Render (F6) → File → Export → STL
+//  3. Raise grid_rows to at least the number of lines you filled in — only the
+//     first grid_rows lines are rendered, and a "TOO MANY LINES" warning tells
+//     you when text is being left off. Lines 9 and 10 live under the
+//     [More Braille Lines (Advanced)] tab.
+//  4. Choose plate_type: Embossing Plate or Counter Plate
+//  5. Choose dot_shape: Rounded or Cone (affects both plates)
+//  6. Adjust dimensions in Expert Mode if needed
+//  7. Render (F6) → File → Export → STL
 //
 // =============================================================================
 // PARAMETER ORGANIZATION
@@ -68,7 +72,8 @@
 //  Parameters are organized to match the web-based generator:
 //
 //  MAIN CONTROLS (always visible):
-//  • Text Input - Pre-Translated Braille
+//  • Text Input - Pre-Translated Braille (Line_1 - Line_8)
+//  • More Braille Lines (Advanced) (Line_9 - Line_10, the grid_rows maximum)
 //  • Plate Selection
 //
 //  EXPERT MODE (expandable submenus matching web UI):
@@ -108,8 +113,21 @@ Line_1 = "⠓⠑⠇⠇⠕"; // First line of braille text
 Line_2 = "⠺⠕⠗⠇⠙"; // Second line of braille text
 Line_3 = ""; // Third line of braille text
 Line_4 = ""; // Fourth line of braille text
+Line_5 = ""; // Fifth line of braille text
+Line_6 = ""; // Sixth line of braille text
+Line_7 = ""; // Seventh line of braille text
+Line_8 = ""; // Eighth line of braille text
 // Show TEXT TOO LONG warning and clip rows to the cell capacity. Off = render every pasted character (rows may crowd the seam).
 text_limit_check = "On"; // [On, Off]
+
+/* [More Braille Lines (Advanced)] */
+// Lines 9 and 10 reach the grid_rows maximum of 10. The Customizer cannot add
+// fields on demand, so these live in their own tab rather than lengthening the
+// text input above. Raise grid_rows under [Expert Mode - Braille Spacing] to
+// match, and give the cylinder the height to hold them: 10 rows at the default
+// 10 mm line_spacing needs about 100 mm.
+Line_9 = ""; // Ninth line of braille text
+Line_10 = ""; // Tenth line of braille text
 
 /* [Plate Selection] */
 // Choose which plate to generate
@@ -482,27 +500,44 @@ if (tactile_gap_too_small)
              tactile_indicator_width + TACTILE_MIN_GAP_MARGIN, " mm; the current layout leaves ",
              seam_gap_mm, " mm. Lower grid_columns or raise cylinder_diameter_mm."));
 
+// The braille text, in row order. This list is the single source of truth for
+// the content: every capacity check, warning, and geometry loop reads it, never
+// a Line_N name. Adding a row means declaring Line_N in the text input section
+// above, appending it here, and raising the grid_rows slider max to match.
+_all_lines = [Line_1, Line_2, Line_3, Line_4, Line_5,
+              Line_6, Line_7, Line_8, Line_9, Line_10];
+
 // Text-capacity check. Text capacity is always active_grid_columns; in Visual mode
 // the grid is widened by 2 marker cells when Indicator Letters are On, or by 1 (the
 // alignment triangle) when Off, and Tactile mode adds none, so text capacity is
 // unchanged in every case. The check (and row clipping) can be bypassed with
 // text_limit_check = "Off", which renders every pasted cell — rows may then crowd
 // the seam.
-max_line_len = max([len(Line_1), len(Line_2), len(Line_3), len(Line_4)]);
+max_line_len = max([for (l = _all_lines) len(l)]);
 text_too_long = (text_limit_check == "On") && (max_line_len > active_grid_columns);
+
+// Row-capacity check. Only the first active_grid_rows rows are ever rendered, so
+// text pasted into a line past that limit vanishes with nothing to show for it.
+// rows_used is the index of the last non-empty line + 1, which preserves blank
+// rows deliberately left between filled ones. Unlike the cell-capacity check this
+// is not gated on text_limit_check: extra rows cannot be rendered anyway, there is
+// no "draw it regardless" option to opt into.
+_filled_row_idx = [for (i = [0 : len(_all_lines) - 1]) if (len(_all_lines[i]) > 0) i];
+rows_used = len(_filled_row_idx) == 0 ? 0 : _filled_row_idx[len(_filled_row_idx) - 1] + 1;
+too_many_rows = rows_used > active_grid_rows;
 
 // Console diagnostics for desktop users (the MakerWorld customizer preview
 // cannot show console output — it relies on the extruded 3D warning text).
 if (text_limit_check == "On") {
-    if (len(Line_1) > active_grid_columns)
-        echo(str("WARNING: Line_1 uses ", len(Line_1), " cells; capacity is ", active_grid_columns, ". Raise grid_columns, split across rows, or set text_limit_check = Off."));
-    if (len(Line_2) > active_grid_columns)
-        echo(str("WARNING: Line_2 uses ", len(Line_2), " cells; capacity is ", active_grid_columns, ". Raise grid_columns, split across rows, or set text_limit_check = Off."));
-    if (len(Line_3) > active_grid_columns)
-        echo(str("WARNING: Line_3 uses ", len(Line_3), " cells; capacity is ", active_grid_columns, ". Raise grid_columns, split across rows, or set text_limit_check = Off."));
-    if (len(Line_4) > active_grid_columns)
-        echo(str("WARNING: Line_4 uses ", len(Line_4), " cells; capacity is ", active_grid_columns, ". Raise grid_columns, split across rows, or set text_limit_check = Off."));
+    for (i = [0 : len(_all_lines) - 1])
+        if (len(_all_lines[i]) > active_grid_columns)
+            echo(str("WARNING: Line_", i + 1, " uses ", len(_all_lines[i]), " cells; capacity is ", active_grid_columns, ". Raise grid_columns, split across rows, or set text_limit_check = Off."));
 }
+if (too_many_rows)
+    echo(str("WARNING: text reaches Line_", rows_used, " but grid_rows is ", active_grid_rows,
+             ", so Line_", active_grid_rows + 1, " onward will not be rendered. Raise grid_rows to ",
+             rows_used, " (the cylinder needs roughly ", rows_used * active_line_spacing,
+             " mm of height to hold that many rows)."));
 grid_height = (active_grid_rows - 1) * active_line_spacing;
 top_margin = (active_cylinder_height_mm - grid_height) / 2;
 
@@ -629,7 +664,9 @@ CYLINDER_SHELL_FN = 64;
 INVALID_TEXT_Z_OFFSET   = 5;   // mm above the cylinder top
 INVALID_TEXT_SIZE       = 5;   // text() font size in mm
 INVALID_TEXT_DEPTH      = 2;   // linear_extrude height in mm
-INVALID_TEXT_STACK_GAP  = 8;   // mm gap above INVALID CHARACTERS to stack TEXT TOO LONG
+// Pitch of the warning stack above INVALID CHARACTERS, one step per warning:
+// TEXT TOO LONG, TACTILE GAP TOO SMALL, then TOO MANY LINES.
+INVALID_TEXT_STACK_GAP  = 8;   // mm
 
 module indicator_triangle_2d(rotate_180 = false) {
     // Isosceles triangle with vertical base on LEFT, apex RIGHT (default).
@@ -899,8 +936,7 @@ module cylinder_emboss_plate() {
                 cylinder_shell(cutout_rotate_deg = -active_seam_offset_degrees);
 
                 // Check for invalid characters
-                invalid_found = has_invalid_chars(Line_1) || has_invalid_chars(Line_2) ||
-                               has_invalid_chars(Line_3) || has_invalid_chars(Line_4);
+                invalid_found = len([for (l = _all_lines) if (has_invalid_chars(l)) 1]) > 0;
                 
                 if (invalid_found) {
                     translate([0, 0, active_cylinder_height_mm/2 + INVALID_TEXT_Z_OFFSET])
@@ -923,23 +959,33 @@ module cylinder_emboss_plate() {
                 // TACTILE GAP TOO SMALL warning (Tactile mode only; no-op otherwise).
                 tactile_gap_warning();
 
+                // TOO MANY LINES warning (see top-level rows_used /
+                // too_many_rows). The dot loop below stops at active_grid_rows,
+                // so without this the text on the extra lines would simply not
+                // appear, with nothing on screen to say why.
+                if (too_many_rows) {
+                    translate([0, 0, active_cylinder_height_mm/2 + INVALID_TEXT_Z_OFFSET + 3 * INVALID_TEXT_STACK_GAP])
+                    color("red")
+                    linear_extrude(height = INVALID_TEXT_DEPTH)
+                    text(str("TOO MANY LINES: ", rows_used, "/", active_grid_rows), size = INVALID_TEXT_SIZE, halign = "center", valign = "center");
+                }
+
                 // Tactile mode: raised alignment arrows in the seam gap, one per row.
                 if (tactile_on) {
                     tactile_rows_raised();
                 }
 
-                // Create braille dots on cylinder surface
-                lines = [Line_1, Line_2, Line_3, Line_4];
-                
-                for (row = [0 : min(active_grid_rows - 1, len(lines) - 1)]) {
-                    if (len(lines[row]) > 0) {
+                // Create braille dots on cylinder surface. Rows past
+                // active_grid_rows are dropped; too_many_rows above warns first.
+                for (row = [0 : min(active_grid_rows - 1, len(_all_lines) - 1)]) {
+                    if (len(_all_lines[row]) > 0) {
                         y_pos = active_cylinder_height_mm/2 - top_margin - (row * active_line_spacing) + active_braille_y_adjust;
                         
                         // Clip each row to the cell capacity unless the user
                         // bypassed the limit (then render every pasted cell).
                         row_last_col = (text_limit_check == "Off")
-                            ? len(lines[row]) - 1
-                            : min(active_grid_columns - 1, len(lines[row]) - 1);
+                            ? len(_all_lines[row]) - 1
+                            : min(active_grid_columns - 1, len(_all_lines[row]) - 1);
                         for (col = [0 : row_last_col]) {
                             // Visual mode: shift past the marker columns — triangle
                             // (always) at col 0, plus the indicator letter square at
@@ -948,7 +994,7 @@ module cylinder_emboss_plate() {
                                          indicator_on ? (col + 2) : (col + 1);
                             angle_rad = start_angle + (actual_col * cell_spacing_angle);
                             angle_deg = angle_rad * 180 / PI;
-                            dots = get_dot_pattern(lines[row][col]);
+                            dots = get_dot_pattern(_all_lines[row][col]);
                             
                             for (i = [0:5]) {
                                 if (dots[i] == 1) {

--- a/OpenSCAD/PARAMETER_MAPPING.md
+++ b/OpenSCAD/PARAMETER_MAPPING.md
@@ -29,7 +29,29 @@ The OpenSCAD version has been updated to match the web-based generator's UI para
 | `Line_2` | Line 2 text input | Must be pre-translated Unicode braille |
 | `Line_3` | Line 3 text input | Must be pre-translated Unicode braille |
 | `Line_4` | Line 4 text input | Must be pre-translated Unicode braille |
+| `Line_5` | Line 5 text input | Must be pre-translated Unicode braille |
+| `Line_6` | Line 6 text input | Must be pre-translated Unicode braille |
+| `Line_7` | Line 7 text input | Must be pre-translated Unicode braille |
+| `Line_8` | Line 8 text input | Must be pre-translated Unicode braille |
 | `text_limit_check` | *(OpenSCAD-only)* | `"On"` (default) shows the `TEXT TOO LONG` warning and clips rows to the cell capacity; `"Off"` renders every pasted cell (rows may crowd the seam). The web app validates cell counts before generation instead. |
+
+### More Braille Lines (Advanced)
+
+`grid_rows` goes up to 10, but the Customizer cannot add input fields on demand
+the way the web app grows its line list. Showing all ten at once would push the
+other tabs off screen for the common case, so the last two live in their own
+collapsed tab. Parameter names are unchanged, so presets and `-D` overrides
+that set `Line_9` / `Line_10` keep working regardless of which tab they display in.
+
+| OpenSCAD Parameter | Web App Equivalent | Notes |
+|--------------------|-------------------|-------|
+| `Line_9` | Line 9 text input | Must be pre-translated Unicode braille; raise `grid_rows` to 9 or more to render it |
+| `Line_10` | Line 10 text input | Must be pre-translated Unicode braille; raise `grid_rows` to 10 to render it |
+
+Only the first `grid_rows` lines are rendered. Filling a line beyond that limit
+triggers a `TOO MANY LINES: n/grid_rows` warning — a console `echo()` plus red
+text above the cylinder for the MakerWorld preview, which has no console. The
+web app blocks the same case before generation instead of warning after.
 
 ### Plate Selection
 | OpenSCAD Parameter | Web App Equivalent | Values |
@@ -91,7 +113,7 @@ user switches preset.
 | OpenSCAD Parameter | Web App Equivalent | Default | Range |
 |--------------------|-------------------|---------|-------|
 | `grid_columns` | Number of Braille Cells | 13 | 1-20 |
-| `grid_rows` | Number of Braille Lines | 4 | 1-10 |
+| `grid_rows` | Number of Braille Lines | 4 | 1-10 (every row has a `Line_N` field; 9 and 10 are under the Advanced tab) |
 | `cell_spacing` | Braille Cell Spacing | 6.5 mm | 2-15 mm |
 | `line_spacing` | Braille Line Spacing | 10.0 mm | 5-25 mm |
 | `dot_spacing` | Braille Dot Spacing | 2.5 mm | 1-5 mm |

--- a/OpenSCAD/README.md
+++ b/OpenSCAD/README.md
@@ -5,8 +5,8 @@
 > | | |
 > |---|---|
 > | **Canonical repo** | [BrennenJohnston/braille-cylinder-stl-generator-openscad](https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad) |
-> | **Vendored from** | tag `v2.4.1` (commit `f31c101`, released 2026-07-29) |
-> | **Copied on** | 2026-07-29 |
+> | **Vendored from** | tag `v2.5.0` (commit `675f7a5`, released 2026-08-01) |
+> | **Copied on** | 2026-08-01 |
 > | **Machine-readable provenance** | [`VENDORED.json`](VENDORED.json) |
 >
 > The standalone repo **is** the active home for this program: it holds the

--- a/OpenSCAD/VENDORED.json
+++ b/OpenSCAD/VENDORED.json
@@ -1,15 +1,15 @@
 {
   "$comment": "Provenance for the vendored OpenSCAD copy. Every file below is copied verbatim from the upstream repository at the recorded tag, except where a note says otherwise. Edit them upstream, never here. Each sha256 is of the bytes this repo ships, which for a file with an 'edited on copy' note is deliberately not the upstream hash; tests/test_vendored_openscad.py fails if any file drifts from its record.",
   "upstream_repo": "https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad",
-  "upstream_tag": "v2.4.1",
-  "upstream_commit": "f31c101356963b4b0d4b12ccae3934ec9dd1aa5c",
-  "upstream_release_date": "2026-07-29",
-  "vendored_on": "2026-07-29",
+  "upstream_tag": "v2.5.0",
+  "upstream_commit": "675f7a524a7672cc2b87023ac966b54b0bf8b334",
+  "upstream_release_date": "2026-08-01",
+  "vendored_on": "2026-08-01",
   "canonical": "upstream",
   "files": {
     "Braille_Cylinder_STL_Generator.scad": {
       "upstream_path": "makerworld/Braille_Cylinder_STL_Generator_MakerWorld_v2.scad",
-      "sha256": "d10c617f7d030e1e0a788f0492fbcec5c6fd2a34e562b3ffacb9b68c42dbed46",
+      "sha256": "42fdc0ead56093361e6290a515d60928e3c5ac01669af5fb47912ca6265fcda9",
       "note": "The MakerWorld single-file build is vendored rather than the dual-file desktop build, so the download is self-contained (no include <presets.scad>). Renamed on copy: this repo ships one file, so the _MakerWorld_v2 suffix would only confuse."
     },
     "LICENSE": {
@@ -18,12 +18,12 @@
     },
     "PARAMETER_MAPPING.md": {
       "upstream_path": "docs/PARAMETER_MAPPING.md",
-      "sha256": "e317fd7f146666b3f09e8e01c819fb25c420b26b503a68619ecc02c8079f0608",
+      "sha256": "dc36726018eff3a5c2afca311a078b5dc297d623d51bc6a6149eee59a5db9f73",
       "note": "One sentence edited on copy: upstream says 'this repository contains only the OpenSCAD cylinder generator', which is false here. The hash covers the edited copy, so it still catches later drift."
     },
     "docs/MAKERWORLD_QUICK_START.md": {
       "upstream_path": "docs/MAKERWORLD_QUICK_START.md",
-      "sha256": "88df50e801bc62b64aac9cf7d03f6a1ce967317706758d098774ba322f01810c"
+      "sha256": "f4895b3c62ae91374fbca7aa6d321558a84df22b6d445b021572998a18f634f2"
     },
     "docs/MakerWorld_Quick_Start_Guide.pdf": {
       "upstream_path": "docs/MakerWorld_Quick_Start_Guide.pdf",

--- a/OpenSCAD/docs/MAKERWORLD_QUICK_START.md
+++ b/OpenSCAD/docs/MAKERWORLD_QUICK_START.md
@@ -19,8 +19,12 @@ prioritize. The core question, per the Braille Authority of North America
 (BANA): *"Can someone identify me and contact me with just this information?"*
 If yes, you have enough.
 
-- Each row holds **13 braille cells of text** by default, and the generator
-  offers **4 lines** (`Line_1`–`Line_4`).
+- Each row holds **13 braille cells of text** by default. The generator offers
+  **10 lines** (`Line_1`–`Line_8` in the main tab, `Line_9`–`Line_10` under
+  **More Braille Lines (Advanced)**), though only the first `grid_rows` of them
+  are rendered — `grid_rows` defaults to **4**, which is the usual business-card
+  layout below. Raise it if you fill more lines; the generator warns you with
+  `TOO MANY LINES` if you forget.
 - BANA's typical four-line business card layout: **name**, **organization**,
   **phone number**, **e-mail address**. Job titles, mailing addresses, fax
   numbers, and websites are usually the first things to cut.
@@ -97,7 +101,10 @@ end of the first line is preferred; omit it only as a last resort. Tip: omit
    **only** `Braille_Cylinder_STL_Generator_MakerWorld_v2.scad`.
 2. In the parameter panel:
    - Paste your Unicode braille into `Line_1`, `Line_2`, `Line_3`, `Line_4`
-     (leave unused lines empty). Do **not** type plain English.
+     (leave unused lines empty). Do **not** type plain English. Lines 5–8 are in
+     the same tab and lines 9–10 under **More Braille Lines (Advanced)**; if you
+     use any line past the fourth, raise `grid_rows` to match or that text will
+     not be rendered.
    - `paper_thickness_preset`: keep `0.4mm` (default) for typical card stock,
      `0.3mm` for thinner paper, or `Custom` to use your own slider values.
      Presets control dot and spacing dimensions; they never change the


### PR DESCRIPTION
## Summary

Re-vendors the offline OpenSCAD copy in `OpenSCAD/` from upstream **v2.5.0** (was v2.4.1).

- The download now carries **`Line_5`–`Line_10`**, closing a gap where the Customizer's `grid_rows` slider allowed up to 10 rows but only four text fields existed. The web app has grown its line list dynamically all along, so the offline copy was the odd one out. `Line_9` and `Line_10` are in a separate `[More Braille Lines (Advanced)]` tab because OpenSCAD cannot add fields on demand.
- Upstream also added a **`TOO MANY LINES: n/grid_rows`** warning for braille typed past the row limit, which previously disappeared from the exported STL with nothing to say so. The web app blocks that case before generation instead, so this is an offline-only improvement.
- Three of the eight recorded files changed: the `.scad` (from the MakerWorld single-file build), `PARAMETER_MAPPING.md`, and `docs/MAKERWORLD_QUICK_START.md`. The other five, including the PDF, were already byte-identical and were left untouched.

Depends on [braille-cylinder-stl-generator-openscad#…](https://github.com/BrennenJohnston/braille-cylinder-stl-generator-openscad/releases/tag/v2.5.0) — the `v2.5.0` tag is pushed and resolves to `675f7a524a7672cc2b87023ac966b54b0bf8b334`, which is what `VENDORED.json` records.

## Two details worth reviewing

- **Line endings.** The vendored tree normalizes to LF, but upstream's `LICENSE` working copy is CRLF. Copying raw bytes would have silently rewritten a file that had not actually changed, so the copy normalizes CRLF to LF (the PDF is copied byte-for-byte).
- **The documented on-copy edit is preserved.** `PARAMETER_MAPPING.md` carries one rewritten sentence — upstream's note says "this repository contains only the OpenSCAD cylinder generator", which is false here. The re-vendor asserts the upstream wording still matches before re-applying the substitution, rather than silently dropping the edit if upstream rewords it.

## Test plan

- [x] Full backend suite green: **46 passed**
- [x] All 12 guards in `tests/test_vendored_openscad.py` pass — every file matches its recorded hash, `VENDORED.json` accounts for the whole folder, and the provenance record resolves to a real tag plus a full 40-character SHA
- [x] `OpenSCAD/README.md` updated to state the new tag, which `test_readme_states_upstream_is_canonical` requires
- [x] **Rendered the vendored `.scad` with OpenSCAD** (`--backend Manifold`) — `Status: NoError`, so the file users download is valid
- [x] Confirmed the copy carries the new features (`Line_10`, the Advanced group, the `TOO MANY LINES` extrusion)
